### PR TITLE
standardize on better-result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,5 @@
 
 - This library supports Node >=20 for consumers; contributors need Node >=24.14.0.
 - npm publishing is configured with GitHub Actions trusted publishing (OIDC + provenance), not long-lived `NPM_TOKEN` auth.
+- The library is designed to be runtime-agnostic, not Node-specific in behavior.
+- The project is currently alpha-stage with no production users, so intentional breaking changes are acceptable.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Runtime requirement for consumers: Node `>=20`.
 ## Quick start
 
 ```ts
-import { Op, TypedError } from "@prodkit/op";
+import { Op, TaggedError } from "@prodkit/op";
 
-class DivisionByZeroError extends TypedError("DivisionByZeroError") {}
+class DivisionByZeroError extends TaggedError("DivisionByZeroError") {}
 
 const divide = Op(function* (a: number, b: number) {
   if (b === 0) yield* new DivisionByZeroError();
@@ -46,7 +46,7 @@ const program = Op(function* () {
 });
 
 const result = await program.run();
-//    ^? Result<number, DivisionByZeroError | "Negative" | UnexpectedError>
+//    ^? Result<number, DivisionByZeroError | "Negative" | UnhandledException>
 if (result.ok) {
   console.log(result.value);
 } else {
@@ -73,7 +73,7 @@ Creates an op that always fails with `error`.
 ### `Op.try(f, onError?)`
 
 Runs an async or sync function and converts failures into `Err`.
-If `onError` is omitted, failures become `UnexpectedError`.
+If `onError` is omitted, failures become `UnhandledException`.
 
 `f` receives an `AbortSignal` that fires when the surrounding `withTimeout` expires. Forward it
 to cancellable APIs so in-flight work (e.g. `fetch`, DB queries) actually stops instead of
@@ -162,13 +162,13 @@ const result = await runPromise;
 
 ## Typed errors
 
-Use `TypedError("Name")` for discriminated domain errors that still behave like real `Error` objects.
+Use `TaggedError("Name")` for discriminated domain errors that still behave like real `Error` objects.
 You can fail with one directly with `yield* new MyError()` inside an op.
 
 ```ts
-import { TypedError, Op } from "@prodkit/op";
+import { TaggedError, Op } from "@prodkit/op";
 
-class ValidationError extends TypedError("ValidationError")<{
+class ValidationError extends TaggedError("ValidationError")<{
   field: string;
 }> {}
 
@@ -202,7 +202,7 @@ const policy = {
 
 ## Built-in errors
 
-- `UnexpectedError`: default wrapper when a thrown/rejected value is not mapped to a domain error.
+- `UnhandledException`: default wrapper when a thrown/rejected value is not mapped to a domain error.
 - `TimeoutError`: produced by `.withTimeout(timeoutMs)` when the budget expires.
 - `ErrorGroup`: produced by `Op.any` when all children fail.
 - `UnreachableError`: internal sentinel used by control flow; exported for completeness, but most
@@ -275,7 +275,7 @@ if (!r.ok && r.error instanceof ErrorGroup) console.log(r.error.errors);
 
 Propagates whichever op settles first — success or failure. Remaining siblings are
 aborted with no library-specific reason. `Op.race([])` fails fast with
-`UnexpectedError`.
+`UnhandledException`.
 
 ```ts
 const r = await Op.race([slow, fast]).run();
@@ -283,7 +283,7 @@ const r = await Op.race([slow, fast]).run();
 
 ## Flagship production example: webhook consumer
 
-See `examples/webhook-flagship.ts` for a complete order webhook pipeline
+See `examples/webhook.ts` for a complete order webhook pipeline
 that demonstrates:
 
 - input validation with typed domain errors

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @prodkit/op
 
-A simple, composable, and predictable library for writing operations in TypeScript.
+A simple, composable, and predictable library for writing operations in TypeScript, built on top of [`better-result`](https://github.com/dmmulroy/better-result).
 
 > [!WARNING]
 > This library is currently in alpha. The API will almost certainly change between releases while it stabilizes.
@@ -11,7 +11,7 @@ policy, and run parallel work without scattering reliability logic across your a
 
 ## Why this exists
 
-Async TypeScript has two huge flaws: you can't see from a function's type what it might fail with, and the standard concurrency helpers happily let sibling tasks keep running after one of them blows up. `@prodkit/op` fixes both. Operations are written as generator functions, which lets the library infer the full error channel straight into the signature, so the compiler tells you exactly which failures you haven't handled yet. Concurrency combinators thread cancellation through every child, so when one fails the rest actually stop instead of burning quota in the background. Retry, timeout, and external cancellation are one chained method each. Minimal runtime dependencies, a small footprint, no runtime to bootstrap, and an API that's easy to learn and use.
+Async TypeScript has two huge flaws: you can't see from a function's type what it might fail with, and the standard concurrency helpers happily let sibling tasks keep running after one of them blows up. `@prodkit/op` fixes both. It builds on `better-result` for the core `Result` model, then adds generator-based composition, typed error inference, and cancellation-aware concurrency on top. Concurrency combinators thread cancellation through every child, so when one fails the rest actually stop instead of burning quota in the background. Retry, timeout, and external cancellation are one chained method each. Minimal runtime dependencies, a small footprint, no runtime to bootstrap, and an API that's easy to learn and use.
 
 ## Installation
 
@@ -104,7 +104,7 @@ const result = await Op.empty.run();
 
 ### `.run(...args)`
 
-Executes the operation and returns `Result<T, E | UnhandledException>`.
+Executes the operation and returns `Result<T, E | UnhandledException>` from `better-result`.
 
 ```ts
 const result = await op.run(...args);

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ policy, and run parallel work without scattering reliability logic across your a
 
 ## Why this exists
 
-Async TypeScript has two huge flaws: you can't see from a function's type what it might fail with, and the standard concurrency helpers happily let sibling tasks keep running after one of them blows up. `@prodkit/op` fixes both. Operations are written as generator functions, which lets the library infer the full error channel straight into the signature, so the compiler tells you exactly which failures you haven't handled yet. Concurrency combinators thread cancellation through every child, so when one fails the rest actually stop instead of burning quota in the background. Retry, timeout, and external cancellation are one chained method each. Zero dependencies, 6kb gzipped, no runtime to bootstrap, and an API that's easy to learn and use.
+Async TypeScript has two huge flaws: you can't see from a function's type what it might fail with, and the standard concurrency helpers happily let sibling tasks keep running after one of them blows up. `@prodkit/op` fixes both. Operations are written as generator functions, which lets the library infer the full error channel straight into the signature, so the compiler tells you exactly which failures you haven't handled yet. Concurrency combinators thread cancellation through every child, so when one fails the rest actually stop instead of burning quota in the background. Retry, timeout, and external cancellation are one chained method each. Minimal runtime dependencies, a small footprint, no runtime to bootstrap, and an API that's easy to learn and use.
 
 ## Installation
 
@@ -26,7 +26,7 @@ Runtime requirement for consumers: Node `>=20`.
 ```ts
 import { Op, TaggedError } from "@prodkit/op";
 
-class DivisionByZeroError extends TaggedError("DivisionByZeroError") {}
+class DivisionByZeroError extends TaggedError("DivisionByZeroError")() {}
 
 const divide = Op(function* (a: number, b: number) {
   if (b === 0) yield* new DivisionByZeroError();
@@ -47,7 +47,7 @@ const program = Op(function* () {
 
 const result = await program.run();
 //    ^? Result<number, DivisionByZeroError | "Negative" | UnhandledException>
-if (result.ok) {
+if (result.isOk()) {
   console.log(result.value);
 } else {
   console.error(result.error);
@@ -75,8 +75,8 @@ Creates an op that always fails with `error`.
 Runs an async or sync function and converts failures into `Err`.
 If `onError` is omitted, failures become `UnhandledException`.
 
-`f` receives an `AbortSignal` that fires when the surrounding `withTimeout` expires. Forward it
-to cancellable APIs so in-flight work (e.g. `fetch`, DB queries) actually stops instead of
+`f` receives an `AbortSignal` tied to surrounding cancellation policy (`withTimeout`, `withSignal`,
+and combinator cancellation). Forward it to cancellable APIs so in-flight work (e.g. `fetch`, DB queries) actually stops instead of
 leaking after a timeout.
 
 ```ts
@@ -104,10 +104,15 @@ const result = await Op.empty.run();
 
 ### `.run(...args)`
 
-Executes the operation and returns:
+Executes the operation and returns `Result<T, E | UnhandledException>`.
 
 ```ts
-type Result<T, E> = { type: "Ok"; ok: true; value: T } | { type: "Err"; ok: false; error: E };
+const result = await op.run(...args);
+if (result.isOk()) {
+  console.log(result.value);
+} else {
+  console.error(result.error);
+}
 ```
 
 ### `.withRetry(policy?)`
@@ -170,7 +175,7 @@ import { TaggedError, Op } from "@prodkit/op";
 
 class ValidationError extends TaggedError("ValidationError")<{
   field: string;
-}> {}
+}>() {}
 
 const validate = Op(function* (name: string) {
   if (name.trim().length === 0) {
@@ -225,7 +230,7 @@ starts immediately. With a cap, `Op.all` stops launching queued children after t
 
 ```ts
 const r = await Op.all([Op.of(1), Op.of("two"), Op.of(true)]).run();
-if (r.ok) {
+if (r.isOk()) {
   const [n, s, b] = r.value; // [number, string, boolean]
 }
 
@@ -234,15 +239,15 @@ const bounded = await Op.all(fetchOps, 5).run(); // at most 5 active children
 
 ### `Op.allSettled(ops, concurrency?)`
 
-Waits for every op and returns a tuple of their `Result`s in input order. Never fails and
-never aborts siblings.
+Waits for every op and returns a tuple of their `Result`s in input order. Never fails and does not
+short-circuit siblings on child failure.
 
 Pass a positive integer `concurrency` to cap how many children run at once. Unlike `Op.all`,
 `Op.allSettled` keeps launching queued children after failures so every input gets a `Result`.
 
 ```ts
 const r = await Op.allSettled([Op.of(1), Op.fail("nope")]).run();
-if (r.ok) {
+if (r.isOk()) {
   const [a, b] = r.value; // Result<number, ...>, Result<never, "nope" | ...>
 }
 ```
@@ -254,7 +259,7 @@ useful for optional/best-effort reads where fallback logic should continue in th
 
 ```ts
 const settled = yield * Op.settle(loadPolicyVersion);
-const policy = settled.ok ? settled.value : "unknown";
+const policy = settled.isOk() ? settled.value : "unknown";
 ```
 
 ### `Op.any(ops)`
@@ -267,8 +272,8 @@ in input index order. Empty input fails with an empty `ErrorGroup`.
 import { ErrorGroup } from "@prodkit/op";
 
 const r = await Op.any([Op.fail("a"), Op.of(42)]).run();
-if (r.ok) console.log(r.value); // 42
-if (!r.ok && r.error instanceof ErrorGroup) console.log(r.error.errors);
+if (r.isOk()) console.log(r.value); // 42
+if (r.isErr() && r.error instanceof ErrorGroup) console.log(r.error.errors);
 ```
 
 ### `Op.race(ops)`

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -14,7 +14,7 @@ export class NegativeError extends Error {
 }
 
 export const divide = Op(function* (a: number, b: number) {
-  if (b === 0) return yield* Op.fail(new DivisionByZeroError());
+  if (b === 0) return yield* new DivisionByZeroError();
   return a / b;
 });
 
@@ -40,7 +40,7 @@ export const parseUser = Op(function* (payload: unknown) {
     !("name" in payload) ||
     typeof payload.name !== "string"
   ) {
-    return yield* Op.fail(new ParseError({ raw: payload }));
+    return yield* new ParseError({ raw: payload });
   }
   return { name: payload.name };
 });

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,20 +1,20 @@
-import { Op, TypedError } from "@prodkit/op";
+import { Op, TaggedError } from "@prodkit/op";
 
-export class DivisionByZeroError extends TypedError("DivisionByZeroError") {}
+export class DivisionByZeroError extends TaggedError("DivisionByZeroError")() {}
 
 export class NegativeError extends Error {
-  type: "NegativeError";
+  _tag: "NegativeError";
   n: number;
 
   constructor(n: number) {
     super();
-    this.type = "NegativeError";
+    this._tag = "NegativeError";
     this.n = n;
   }
 }
 
 export const divide = Op(function* (a: number, b: number) {
-  if (b === 0) return yield* new DivisionByZeroError();
+  if (b === 0) return yield* Op.fail(new DivisionByZeroError());
   return a / b;
 });
 
@@ -29,40 +29,9 @@ export const mathComposeProgram = Op(function* () {
   return rooted * 2;
 });
 
-export class FetchError extends Error {
-  type: "FetchError";
-  cause: unknown;
-
-  constructor({ cause }: { cause: unknown }) {
-    super();
-    this.type = "FetchError";
-    this.cause = cause;
-  }
-}
-
-export class HttpError extends Error {
-  type: "HttpError";
-  status: number;
-  statusText: string;
-
-  constructor({ status, statusText }: { status: number; statusText: string }) {
-    super();
-    this.type = "HttpError";
-    this.status = status;
-    this.statusText = statusText;
-  }
-}
-
-export class ParseError extends Error {
-  type: "ParseError";
-  raw: unknown;
-
-  constructor({ raw }: { raw: unknown }) {
-    super();
-    this.type = "ParseError";
-    this.raw = raw;
-  }
-}
+export class FetchError extends TaggedError("FetchError")() {}
+export class HttpError extends TaggedError("HttpError")<{ status: number; statusText: string }>() {}
+export class ParseError extends TaggedError("ParseError")<{ raw: unknown }>() {}
 
 export const parseUser = Op(function* (payload: unknown) {
   if (

--- a/examples/smoke.ts
+++ b/examples/smoke.ts
@@ -1,4 +1,4 @@
-import { ErrorGroup, Op, TimeoutError, TypedError, UnexpectedError } from "@prodkit/op";
+import { ErrorGroup, Op, TimeoutError, TaggedError, UnhandledException } from "@prodkit/op";
 import {
   DivisionByZeroError,
   FetchError,
@@ -18,7 +18,7 @@ import {
   InvalidWebhookError,
   ServiceCallError,
   createApp,
-} from "./webhook-flagship.ts";
+} from "./webhook.ts";
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
@@ -67,7 +67,7 @@ const webhookPayload = {
 };
 
 const runCoreApiSmoke = async () => {
-  class TooSmallError extends TypedError("TooSmallError") {}
+  class TooSmallError extends TaggedError("TooSmallError")<{ message: string }>() {}
 
   const localDivide = Op(function* (a: number, b: number) {
     if (b === 0) return yield* Op.fail(new TooSmallError({ message: "division by zero" }));
@@ -75,7 +75,7 @@ const runCoreApiSmoke = async () => {
   });
 
   const localSqrt = Op(function* (n: number) {
-    if (n < 0) return yield* new TooSmallError({ message: "negative input" });
+    if (n < 0) return yield* Op.fail(new TooSmallError({ message: "negative input" }));
     return Math.sqrt(n);
   });
 
@@ -94,7 +94,7 @@ const runCoreApiSmoke = async () => {
     .withTimeout(500)
     .run();
 
-  assert(result.ok && result.value === Math.sqrt(5), "core smoke computation failed");
+  assert(result.isOk() && result.value === Math.sqrt(5), "core smoke computation failed");
 
   const timeoutResult = await Op.try(
     (signal) =>
@@ -109,48 +109,51 @@ const runCoreApiSmoke = async () => {
     .withTimeout(1)
     .run();
 
-  assert(!timeoutResult.ok && timeoutResult.error instanceof TimeoutError, "timeout smoke failed");
+  assert(
+    timeoutResult.isErr() && timeoutResult.error instanceof TimeoutError,
+    "timeout smoke failed",
+  );
 
   const unexpectedResult = await Op.try(() => {
     throw "boom";
   }).run();
 
   assert(
-    !unexpectedResult.ok && unexpectedResult.error instanceof UnexpectedError,
+    unexpectedResult.isErr() && unexpectedResult.error instanceof UnhandledException,
     "unexpected error smoke failed",
   );
 };
 
 const runSimpleExampleSmoke = async () => {
   const divideOk = await divide.run(10, 2);
-  assert(divideOk.ok && divideOk.value === 5, "divide success check failed");
+  assert(divideOk.isOk() && divideOk.value === 5, "divide success check failed");
 
   const divideErr = await divide.run(10, 0);
   assert(
-    !divideErr.ok && divideErr.error instanceof DivisionByZeroError,
+    divideErr.isErr() && divideErr.error instanceof DivisionByZeroError,
     "divide error check failed",
   );
 
   const sqrtOk = await sqrt.run(9);
-  assert(sqrtOk.ok && sqrtOk.value === 3, "sqrt success check failed");
+  assert(sqrtOk.isOk() && sqrtOk.value === 3, "sqrt success check failed");
 
   const sqrtErr = await sqrt.run(-1);
-  assert(!sqrtErr.ok && sqrtErr.error instanceof NegativeError, "sqrt error check failed");
-  if (!sqrtErr.ok && sqrtErr.error instanceof NegativeError) {
+  assert(sqrtErr.isErr() && sqrtErr.error instanceof NegativeError, "sqrt error check failed");
+  if (sqrtErr.isErr() && sqrtErr.error instanceof NegativeError) {
     assert(sqrtErr.error.n === -1, "negative error payload check failed");
   }
 
   const composeResult = await mathComposeProgram.run();
   assert(
-    !composeResult.ok && composeResult.error instanceof NegativeError,
+    composeResult.isErr() && composeResult.error instanceof NegativeError,
     "mathComposeProgram failure check failed",
   );
 
   const parseOk = await parseUser.run({ name: "Ada" });
-  assert(parseOk.ok && parseOk.value.name === "Ada", "parseUser success check failed");
+  assert(parseOk.isOk() && parseOk.value.name === "Ada", "parseUser success check failed");
 
   const parseErr = await parseUser.run({ notName: 1 });
-  assert(!parseErr.ok && parseErr.error instanceof ParseError, "parseUser error check failed");
+  assert(parseErr.isErr() && parseErr.error instanceof ParseError, "parseUser error check failed");
 
   const originalFetch = globalThis.fetch;
   try {
@@ -161,17 +164,17 @@ const runSimpleExampleSmoke = async () => {
       });
     const fetchOk = await fetchData.run("https://example.test/api/users/1");
     assert(
-      fetchOk.ok && isNamedUser(fetchOk.value) && fetchOk.value.name === "Ada",
+      fetchOk.isOk() && isNamedUser(fetchOk.value) && fetchOk.value.name === "Ada",
       "fetchData success check failed",
     );
 
     globalThis.fetch = async () => new Response(null, { status: 404, statusText: "Not Found" });
     const fetchErr = await fetchData.run("https://example.test/missing");
     assert(
-      !fetchErr.ok && fetchErr.error instanceof FetchError,
+      fetchErr.isErr() && fetchErr.error instanceof FetchError,
       "fetchData error type check failed",
     );
-    if (!fetchErr.ok) {
+    if (fetchErr.isErr()) {
       assert(fetchErr.error.cause instanceof HttpError, "fetchData cause type check failed");
     }
 
@@ -183,7 +186,7 @@ const runSimpleExampleSmoke = async () => {
       });
     };
     const userOk = await userProgram.run("123");
-    assert(userOk.ok && userOk.value.name === "Ada", "userProgram composition check failed");
+    assert(userOk.isOk() && userOk.value.name === "Ada", "userProgram composition check failed");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -202,8 +205,8 @@ const runWebhookExampleSmoke = async () => {
     }),
   );
   const happyPath = await appWithWarning.processOrderWebhook.run(webhookPayload);
-  assert(happyPath.ok, "webhook happy path check failed");
-  if (happyPath.ok) {
+  assert(happyPath.isOk(), "webhook happy path check failed");
+  if (happyPath.isOk()) {
     assert(happyPath.value.orderId === "ord-123", "happy path order id check failed");
     assert(happyPath.value.authorizationId === "auth-1", "happy path authorization check failed");
     assert(happyPath.value.warnings.length === 1, "happy path warnings check failed");
@@ -213,7 +216,7 @@ const runWebhookExampleSmoke = async () => {
   const duplicateApp = createApp(createDeps({ isDuplicateEvent: async () => true }));
   const duplicate = await duplicateApp.processOrderWebhook.run(webhookPayload);
   assert(
-    !duplicate.ok && duplicate.error instanceof DuplicateEventError,
+    duplicate.isErr() && duplicate.error instanceof DuplicateEventError,
     "duplicate event check failed",
   );
 
@@ -222,7 +225,7 @@ const runWebhookExampleSmoke = async () => {
     totalCents: -1,
   });
   assert(
-    !invalidNegativeCents.ok && invalidNegativeCents.error instanceof InvalidWebhookError,
+    invalidNegativeCents.isErr() && invalidNegativeCents.error instanceof InvalidWebhookError,
     "negative totalCents validation check failed",
   );
 
@@ -231,7 +234,7 @@ const runWebhookExampleSmoke = async () => {
     totalCents: Number.NaN,
   });
   assert(
-    !invalidNaNCents.ok && invalidNaNCents.error instanceof InvalidWebhookError,
+    invalidNaNCents.isErr() && invalidNaNCents.error instanceof InvalidWebhookError,
     "NaN totalCents validation check failed",
   );
 
@@ -246,7 +249,7 @@ const runWebhookExampleSmoke = async () => {
     }),
   );
   const retryPayment = await retryPaymentApp.processOrderWebhook.run(webhookPayload);
-  assert(retryPayment.ok, "retry payment check failed");
+  assert(retryPayment.isOk(), "retry payment check failed");
   assert(paymentAttempts === 2, "retry payment attempts check failed");
 
   const fallbackRiskApp = createApp(
@@ -258,7 +261,7 @@ const runWebhookExampleSmoke = async () => {
     }),
   );
   const fallbackRisk = await fallbackRiskApp.processOrderWebhook.run(webhookPayload);
-  assert(fallbackRisk.ok && fallbackRisk.value.riskScore === 0.2, "risk fallback check failed");
+  assert(fallbackRisk.isOk() && fallbackRisk.value.riskScore === 0.2, "risk fallback check failed");
 
   const allRiskFailApp = createApp(
     createDeps({
@@ -271,12 +274,15 @@ const runWebhookExampleSmoke = async () => {
     }),
   );
   const allRiskFail = await allRiskFailApp.processOrderWebhook.run(webhookPayload);
-  assert(!allRiskFail.ok && allRiskFail.error instanceof ErrorGroup, "all-risk-fail check failed");
+  assert(
+    allRiskFail.isErr() && allRiskFail.error instanceof ErrorGroup,
+    "all-risk-fail check failed",
+  );
 
   const fraudApp = createApp(createDeps({ riskPrimary: async () => 0.97 }));
   const fraudResult = await fraudApp.processOrderWebhook.run(webhookPayload);
   assert(
-    !fraudResult.ok && fraudResult.error instanceof FraudRiskTooHighError,
+    fraudResult.isErr() && fraudResult.error instanceof FraudRiskTooHighError,
     "fraud gate check failed",
   );
 
@@ -299,7 +305,7 @@ const runWebhookExampleSmoke = async () => {
   );
   const abortedInventoryResult = await abortedInventoryApp.processOrderWebhook.run(webhookPayload);
   assert(
-    !abortedInventoryResult.ok && abortedInventoryResult.error instanceof ServiceCallError,
+    abortedInventoryResult.isErr() && abortedInventoryResult.error instanceof ServiceCallError,
     "inventory abort error type check failed",
   );
   assert(inventoryAborted, "inventory abort propagation check failed");

--- a/examples/smoke.ts
+++ b/examples/smoke.ts
@@ -26,19 +26,21 @@ const assert = (condition: unknown, message: string) => {
 
 const isNamedUser = (value: unknown): value is { name: string } => {
   return (
-    typeof value === "object" &&
-    value !== null &&
-    "name" in value &&
-    typeof (value as { name?: unknown }).name === "string"
+    typeof value === "object" && value !== null && "name" in value && typeof value.name === "string"
   );
 };
 
-const retryableError = (message: string) => Object.assign(new Error(message), { retryable: true });
+const makeRetryableError = (message: string) => {
+  const error = new Error(message);
+  Object.assign(error, { retryable: true });
+  Error.captureStackTrace(error, makeRetryableError);
+  return error;
+};
 
 const neverSettlesUntilAborted = (signal: AbortSignal) =>
   new Promise((_, reject) => {
-    if (signal.aborted) return reject(retryableError("aborted"));
-    signal.addEventListener("abort", () => reject(retryableError("aborted")), { once: true });
+    if (signal.aborted) return reject(makeRetryableError("aborted"));
+    signal.addEventListener("abort", () => reject(makeRetryableError("aborted")), { once: true });
   });
 
 const createDeps = (overrides = {}) => ({
@@ -70,12 +72,12 @@ const runCoreApiSmoke = async () => {
   class TooSmallError extends TaggedError("TooSmallError")<{ message: string }>() {}
 
   const localDivide = Op(function* (a: number, b: number) {
-    if (b === 0) return yield* Op.fail(new TooSmallError({ message: "division by zero" }));
+    if (b === 0) return yield* new TooSmallError({ message: "division by zero" });
     return a / b;
   });
 
   const localSqrt = Op(function* (n: number) {
-    if (n < 0) return yield* Op.fail(new TooSmallError({ message: "negative input" }));
+    if (n < 0) return yield* new TooSmallError({ message: "negative input" });
     return Math.sqrt(n);
   });
 
@@ -243,7 +245,7 @@ const runWebhookExampleSmoke = async () => {
     createDeps({
       authorizePayment: async () => {
         paymentAttempts += 1;
-        if (paymentAttempts === 1) throw retryableError("payment timeout");
+        if (paymentAttempts === 1) throw makeRetryableError("payment timeout");
         return { approved: true, authorizationId: "auth-retried" };
       },
     }),
@@ -255,7 +257,7 @@ const runWebhookExampleSmoke = async () => {
   const fallbackRiskApp = createApp(
     createDeps({
       riskPrimary: async () => {
-        throw retryableError("primary unavailable");
+        throw makeRetryableError("primary unavailable");
       },
       riskSecondary: async () => 0.2,
     }),
@@ -266,10 +268,10 @@ const runWebhookExampleSmoke = async () => {
   const allRiskFailApp = createApp(
     createDeps({
       riskPrimary: async () => {
-        throw retryableError("primary unavailable");
+        throw makeRetryableError("primary unavailable");
       },
       riskSecondary: async () => {
-        throw retryableError("secondary unavailable");
+        throw makeRetryableError("secondary unavailable");
       },
     }),
   );
@@ -295,7 +297,7 @@ const runWebhookExampleSmoke = async () => {
           throw new Error("unreachable");
         } catch {
           inventoryAborted = signal.aborted;
-          throw retryableError("inventory aborted");
+          throw makeRetryableError("inventory aborted");
         }
       },
       authorizePayment: async () => {

--- a/examples/webhook.ts
+++ b/examples/webhook.ts
@@ -1,4 +1,4 @@
-import { Op, TypedError } from "@prodkit/op";
+import { Op, TaggedError } from "@prodkit/op";
 
 type WebhookPayload = {
   eventId: string;
@@ -58,6 +58,15 @@ const retryTransient = {
 const BEST_EFFORT_SIDE_EFFECT_CONCURRENCY = 1;
 
 const isString = (value: unknown): value is string => typeof value === "string";
+const formatWarning = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
 
 const parseWebhook = (raw: unknown): WebhookPayload | null => {
   if (typeof raw !== "object" || raw === null) return null;
@@ -86,26 +95,29 @@ const parseWebhook = (raw: unknown): WebhookPayload | null => {
   };
 };
 
-export class InvalidWebhookError extends TypedError("InvalidWebhookError")<{
+export class InvalidWebhookError extends TaggedError("InvalidWebhookError")<{
   issues: string;
-}> {}
-export class DuplicateEventError extends TypedError("DuplicateEventError")<{ eventId: string }> {}
-export class FraudRiskTooHighError extends TypedError("FraudRiskTooHighError")<{
+}>() {}
+export class DuplicateEventError extends TaggedError("DuplicateEventError")<{
+  eventId: string;
+}>() {}
+export class FraudRiskTooHighError extends TaggedError("FraudRiskTooHighError")<{
   userId: string;
   score: number;
   threshold: number;
-}> {}
-export class InventoryUnavailableError extends TypedError("InventoryUnavailableError")<{
+}>() {}
+export class InventoryUnavailableError extends TaggedError("InventoryUnavailableError")<{
   orderId: string;
-}> {}
-export class PaymentDeclinedError extends TypedError("PaymentDeclinedError")<{
+}>() {}
+export class PaymentDeclinedError extends TaggedError("PaymentDeclinedError")<{
   orderId: string;
-}> {}
-
-export class ServiceCallError extends TypedError("ServiceCallError")<{
+  message: string;
+}>() {}
+export class ServiceCallError extends TaggedError("ServiceCallError")<{
   service: string;
   retryable: boolean;
-}> {
+  cause?: unknown;
+}>() {
   static from(service: string, cause: unknown) {
     if (cause instanceof ServiceCallError) return cause;
     const retryable =
@@ -123,7 +135,7 @@ export const createApp = (deps: AppDeps) => {
   const parseWebhookPayload = Op(function* (raw: unknown) {
     const payload = parseWebhook(raw);
     if (payload === null) {
-      return yield* new InvalidWebhookError({ issues: "Invalid webhook payload shape" });
+      return yield* Op.fail(new InvalidWebhookError({ issues: "Invalid webhook payload shape" }));
     }
     return payload;
   });
@@ -136,7 +148,7 @@ export const createApp = (deps: AppDeps) => {
       .withRetry(retryTransient)
       .withTimeout(300);
 
-    if (duplicate) return yield* new DuplicateEventError({ eventId });
+    if (duplicate) return yield* Op.fail(new DuplicateEventError({ eventId }));
     return;
   });
 
@@ -182,7 +194,7 @@ export const createApp = (deps: AppDeps) => {
       .withTimeout(500);
 
     if (!reservation.reserved) {
-      return yield* new InventoryUnavailableError({ orderId: payload.orderId });
+      return yield* Op.fail(new InventoryUnavailableError({ orderId: payload.orderId }));
     }
     return reservation;
   });
@@ -196,30 +208,40 @@ export const createApp = (deps: AppDeps) => {
       .withTimeout(500);
 
     if (!payment.approved || payment.authorizationId === undefined) {
-      return yield* new PaymentDeclinedError({
-        orderId: payload.orderId,
-        message: payment.declineReason ?? "Payment provider declined authorization",
-      });
+      return yield* Op.fail(
+        new PaymentDeclinedError({
+          orderId: payload.orderId,
+          message: payment.declineReason ?? "Payment provider declined authorization",
+        }),
+      );
     }
 
-    return { ...payment, authorizationId: payment.authorizationId };
+    return { approved: true as const, authorizationId: payment.authorizationId };
   });
 
   const processOrderWebhook = Op(function* (raw: unknown) {
     const payload = yield* parseWebhookPayload(raw);
     yield* checkDuplicate(payload.eventId);
 
+    const warnings: string[] = [];
     const policyVersionResult = yield* Op.settle(loadFraudPolicyVersion);
-    const fraudPolicyVersion = policyVersionResult.ok ? policyVersionResult.value : "unknown";
+    const fraudPolicyVersion = policyVersionResult.isOk()
+      ? policyVersionResult.value
+      : "policy-unavailable";
+    if (policyVersionResult.isErr()) {
+      warnings.push(`fraud policy fallback: ${formatWarning(policyVersionResult.error)}`);
+    }
 
     const riskScore = yield* pickRiskScore(payload.userId);
     const riskThreshold = 0.9;
     if (riskScore >= riskThreshold) {
-      return yield* new FraudRiskTooHighError({
-        userId: payload.userId,
-        score: riskScore,
-        threshold: riskThreshold,
-      });
+      return yield* Op.fail(
+        new FraudRiskTooHighError({
+          userId: payload.userId,
+          score: riskScore,
+          threshold: riskThreshold,
+        }),
+      );
     }
 
     // Unbounded fan-out is right when every child should start immediately and fail-fast together.
@@ -270,9 +292,8 @@ export const createApp = (deps: AppDeps) => {
       BEST_EFFORT_SIDE_EFFECT_CONCURRENCY,
     );
 
-    const warnings: string[] = [];
-    if (!receiptResult.ok) warnings.push(String(receiptResult.error));
-    if (!analyticsResult.ok) warnings.push(String(analyticsResult.error));
+    if (receiptResult.isErr()) warnings.push(formatWarning(receiptResult.error));
+    if (analyticsResult.isErr()) warnings.push(formatWarning(analyticsResult.error));
     return { ...processed, warnings };
   });
 

--- a/examples/webhook.ts
+++ b/examples/webhook.ts
@@ -135,7 +135,7 @@ export const createApp = (deps: AppDeps) => {
   const parseWebhookPayload = Op(function* (raw: unknown) {
     const payload = parseWebhook(raw);
     if (payload === null) {
-      return yield* Op.fail(new InvalidWebhookError({ issues: "Invalid webhook payload shape" }));
+      return yield* new InvalidWebhookError({ issues: "Invalid webhook payload shape" });
     }
     return payload;
   });
@@ -148,7 +148,7 @@ export const createApp = (deps: AppDeps) => {
       .withRetry(retryTransient)
       .withTimeout(300);
 
-    if (duplicate) return yield* Op.fail(new DuplicateEventError({ eventId }));
+    if (duplicate) return yield* new DuplicateEventError({ eventId });
     return;
   });
 
@@ -194,7 +194,7 @@ export const createApp = (deps: AppDeps) => {
       .withTimeout(500);
 
     if (!reservation.reserved) {
-      return yield* Op.fail(new InventoryUnavailableError({ orderId: payload.orderId }));
+      return yield* new InventoryUnavailableError({ orderId: payload.orderId });
     }
     return reservation;
   });
@@ -208,12 +208,10 @@ export const createApp = (deps: AppDeps) => {
       .withTimeout(500);
 
     if (!payment.approved || payment.authorizationId === undefined) {
-      return yield* Op.fail(
-        new PaymentDeclinedError({
-          orderId: payload.orderId,
-          message: payment.declineReason ?? "Payment provider declined authorization",
-        }),
-      );
+      return yield* new PaymentDeclinedError({
+        orderId: payload.orderId,
+        message: payment.declineReason ?? "Payment provider declined authorization",
+      });
     }
 
     return { approved: true as const, authorizationId: payment.authorizationId };
@@ -235,13 +233,11 @@ export const createApp = (deps: AppDeps) => {
     const riskScore = yield* pickRiskScore(payload.userId);
     const riskThreshold = 0.9;
     if (riskScore >= riskThreshold) {
-      return yield* Op.fail(
-        new FraudRiskTooHighError({
-          userId: payload.userId,
-          score: riskScore,
-          threshold: riskThreshold,
-        }),
-      );
+      return yield* new FraudRiskTooHighError({
+        userId: payload.userId,
+        score: riskScore,
+        threshold: riskThreshold,
+      });
     }
 
     // Unbounded fan-out is right when every child should start immediately and fail-fast together.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prodkit/op",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prodkit/op",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "better-result": "^2.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@prodkit/op",
       "version": "0.1.16",
       "license": "MIT",
+      "dependencies": {
+        "better-result": "^2.8.2"
+      },
       "devDependencies": {
         "@types/node": "^20.19.37",
         "oxfmt": "^0.40.0",
@@ -733,6 +736,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
+    },
+    "node_modules/better-result": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.8.2.tgz",
+      "integrity": "sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==",
+      "license": "MIT"
     },
     "node_modules/birpc": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prodkit/op",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prodkit/op",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "better-result": "^2.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prodkit/op",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prodkit/op",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "better-result": "^2.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
-        "better-result": "^2.8.2"
+        "better-result": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^20.19.37",
@@ -194,9 +194,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -212,9 +209,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -245,9 +239,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,9 +254,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,9 +363,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -393,9 +378,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,9 +395,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -433,9 +412,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -453,9 +429,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -473,9 +446,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,9 +708,9 @@
       }
     },
     "node_modules/better-result": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.8.2.tgz",
-      "integrity": "sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.0.tgz",
+      "integrity": "sha512-NHwGDGVbRlWDOce3CwcfGIrcNR9zY37ut3SVwQVfv57DZdVhxjhA4mfaHN1n8QwWnRAR4iErpW1X/eaiaUaFYg==",
       "license": "MIT"
     },
     "node_modules/birpc": {
@@ -942,9 +912,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -964,9 +931,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1072,9 +1036,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1096,9 +1057,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1338,9 +1296,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,9 +1313,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1378,9 +1330,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,9 +1347,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1418,9 +1364,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,9 +1381,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1671,9 +1611,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1691,9 +1628,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1711,9 +1645,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,9 +1662,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1751,9 +1679,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1771,9 +1696,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,9 +2001,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,9 +2018,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,9 +2035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2139,9 +2052,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,9 +2456,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,9 +2473,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prodkit/op",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "A simple, composable library for writing predictable operations in TypeScript.",
   "keywords": [
     "composition",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "better-result": "^2.8.2"
+    "better-result": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prodkit/op",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "A simple, composable library for writing predictable operations in TypeScript.",
   "keywords": [
     "composition",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prodkit/op",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A simple, composable library for writing predictable operations in TypeScript.",
   "keywords": [
     "composition",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "better-result": "^2.8.2"
+  },
   "devDependencies": {
     "@types/node": "^20.19.37",
     "oxfmt": "^0.40.0",

--- a/src/builders.test.ts
+++ b/src/builders.test.ts
@@ -1,41 +1,41 @@
 import { describe, expect, test, assert, expectTypeOf } from "vitest";
 import { fail, fromGenFn, succeed, _try } from "./builders.js";
-import { TimeoutError, UnexpectedError, TypedError } from "./errors.js";
+import { TimeoutError, UnhandledException, TaggedError } from "./errors.js";
 import type { Op } from "./core.js";
 import type { Result } from "./result.js";
 
 describe("succeed", () => {
   test("run returns Ok with value", async () => {
     const result = await succeed(69).run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(69);
   });
 
   test("handles various value types", async () => {
     const r1 = await succeed(0).run();
-    assert(r1.ok === true, "r1.ok should be true");
+    assert(r1.isOk() === true, "should be Ok");
     expect(r1.value).toBe(0);
 
     const r2 = await succeed("").run();
-    assert(r2.ok === true, "r2.ok should be true");
+    assert(r2.isOk() === true, "should be Ok");
     expect(r2.value).toBe("");
 
     const r3 = await succeed(null).run();
-    assert(r3.ok === true, "r3.ok should be true");
+    assert(r3.isOk() === true, "should be Ok");
     expect(r3.value).toBe(null);
 
     const r4 = await succeed({ foo: "bar" }).run();
-    assert(r4.ok === true, "r4.ok should be true");
+    assert(r4.isOk() === true, "should be Ok");
     expect(r4.value).toEqual({ foo: "bar" });
 
     const r5 = await succeed([1, 2, 3]).run();
-    assert(r5.ok === true, "r5.ok should be true");
+    assert(r5.isOk() === true, "should be Ok");
     expect(r5.value).toEqual([1, 2, 3]);
   });
 
   test("handles promises", async () => {
     const result = await succeed(Promise.resolve(69)).run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(69);
 
     const program = fromGenFn(function* () {
@@ -44,7 +44,7 @@ describe("succeed", () => {
       return a + b;
     });
     const result2 = await program.run();
-    assert(result2.ok === true, "result2.ok should be true");
+    assert(result2.isOk() === true, "should be Ok");
     expect(result2.value).toBe(3);
   });
 });
@@ -52,14 +52,14 @@ describe("succeed", () => {
 describe("fail", () => {
   test("run returns Err with error", async () => {
     const result = await fail("error").run();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBe("error");
   });
 
   test("preserves custom error objects", async () => {
     const customErr = new Error("custom message");
     const result = await fail(customErr).run();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBe(customErr);
     expect(result.error.message).toBe("custom message");
   });
@@ -72,7 +72,7 @@ describe("fail", () => {
       return yield* succeed(1);
     });
     const result = await program.run();
-    expect(result.ok).toBe(false);
+    expect(result.isErr()).toBe(true);
     expect(executed).toBe(false);
   });
 });
@@ -84,7 +84,7 @@ describe("_try", () => {
       () => "err",
     );
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(1);
   });
 
@@ -94,7 +94,7 @@ describe("_try", () => {
         () => Promise.reject("failed"),
         (e) => `mapped: ${e}`,
       ).run();
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "should be Err");
       expect(result.error).toBe("mapped: failed");
     }
   });
@@ -107,11 +107,11 @@ describe("_try", () => {
       },
       (e) => `mapped: ${e}`,
     ).run();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBe(`mapped: ${syncThrow}`);
   });
 
-  test("UnexpectedError when promise rejects without proper handling", async () => {
+  test("UnhandledException when promise rejects without proper handling", async () => {
     const testError = new TypeError("whoops");
     const result = await fromGenFn(function* () {
       const x = yield* _try(
@@ -122,12 +122,12 @@ describe("_try", () => {
       );
       return x;
     }).run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(result.error.cause).toBe(testError);
   });
 
-  test("UnexpectedError when onError throws", async () => {
+  test("UnhandledException when onError throws", async () => {
     const error = new Error("onError threw");
     const result = await _try(
       () => Promise.reject("boom"),
@@ -135,8 +135,8 @@ describe("_try", () => {
         throw error;
       },
     ).run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(result.error.cause).toBeInstanceOf(Error);
     expect(result.error.cause).toBe(error);
   });
@@ -149,7 +149,7 @@ describe("gen", () => {
       const b = yield* succeed(2);
       return a + b;
     }).run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(3);
   });
 
@@ -163,7 +163,7 @@ describe("gen", () => {
       return yield* succeed(2);
     }).run();
     expect(firstRan).toBe(true);
-    assert(result.ok === false, "result.ok should be true");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBe("oops");
     expect(secondRan).toBe(false);
   });
@@ -177,7 +177,7 @@ describe("gen", () => {
       );
       return b;
     }).run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(20);
   });
 
@@ -190,7 +190,7 @@ describe("gen", () => {
       );
     });
     const result = await p.run();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toEqual({ mapped: "async fail" });
   });
 
@@ -199,8 +199,8 @@ describe("gen", () => {
       return yield* _try(() => Promise.reject("async fail"));
     });
     const result = await p.run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
   });
 
   test("parameterized gen - run passes args into the generator", async () => {
@@ -208,7 +208,7 @@ describe("gen", () => {
       return a + b;
     });
     const result = await add(2, 3).run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(5);
   });
 
@@ -221,8 +221,8 @@ describe("gen", () => {
     });
     const viaRun = await program.run();
     const viaFreeRun = await program.run();
-    assert(viaRun.ok === true, "viaRun.ok should be true");
-    assert(viaFreeRun.ok === true, "viaFreeRun.ok should be true");
+    assert(viaRun.isOk() === true, "should be Ok");
+    assert(viaFreeRun.isOk() === true, "should be Ok");
     expect(viaRun.value).toBe(3);
     expect(viaFreeRun.value).toBe(3);
   });
@@ -233,8 +233,8 @@ describe("gen", () => {
     });
     const a = await program.run();
     const b = await program.run();
-    assert(a.ok === true, "a.ok should be true");
-    assert(b.ok === true, "b.ok should be true");
+    assert(a.isOk() === true, "should be Ok");
+    assert(b.isOk() === true, "should be Ok");
     expect(a.value).toBe(69);
     expect(b.value).toBe(69);
   });
@@ -255,7 +255,7 @@ describe("type inference", () => {
     const p4 = fail("error");
     expectTypeOf(p4).toEqualTypeOf<Op<never, string, []>>();
     const p5 = _try(() => Promise.resolve(1));
-    expectTypeOf(p5).toEqualTypeOf<Op<number, UnexpectedError, []>>();
+    expectTypeOf(p5).toEqualTypeOf<Op<number, UnhandledException, []>>();
     const p6 = _try(
       () => Promise.resolve(1),
       () => "error",
@@ -266,17 +266,17 @@ describe("type inference", () => {
     const p1 = fromGenFn(function* () {
       return yield* succeed(1);
     }).run();
-    expectTypeOf(p1).toEqualTypeOf<Promise<Result<number, UnexpectedError>>>();
+    expectTypeOf(p1).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
     const p2 = fromGenFn(function* (a: string) {
       return yield* succeed(a);
     }).run("hello");
-    expectTypeOf(p2).toEqualTypeOf<Promise<Result<string, UnexpectedError>>>();
+    expectTypeOf(p2).toEqualTypeOf<Promise<Result<string, UnhandledException>>>();
   });
   test("op.run() arity is enforced by the type checker", async () => {
     const p1 = fromGenFn(function* () {
       return yield* succeed(1);
     });
-    expect((await p1.run()).ok).toBe(true);
+    expect((await p1.run()).isOk()).toBe(true);
     // @ts-expect-error - nullary run does not accept arguments
     p1.run(1);
 
@@ -288,13 +288,13 @@ describe("type inference", () => {
     // @ts-expect-error - too many arguments
     p2.run(1, 2); // note: not enforced at runtime
     const r2 = await p2.run(69);
-    assert(r2.ok === true, "r2.ok should be true");
+    assert(r2.isOk() === true, "should be Ok");
     expect(r2.value).toBe(69);
   });
 
   test("withRetry preserves inferred op shapes", async () => {
     const p1 = _try(() => Promise.resolve(1)).withRetry();
-    expectTypeOf(p1).toEqualTypeOf<Op<number, UnexpectedError, []>>();
+    expectTypeOf(p1).toEqualTypeOf<Op<number, UnhandledException, []>>();
 
     const p2 = _try(
       () => Promise.resolve(1),
@@ -311,18 +311,18 @@ describe("type inference", () => {
       const v = yield* _try(() => Promise.resolve(1)).withRetry();
       return v + 1;
     });
-    expectTypeOf(nested).toEqualTypeOf<Op<number, UnexpectedError, []>>();
+    expectTypeOf(nested).toEqualTypeOf<Op<number, UnhandledException, []>>();
 
     const r1 = p1.run();
-    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, UnexpectedError>>>();
+    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
 
     const r2 = p2.run();
-    expectTypeOf(r2).toEqualTypeOf<Promise<Result<number, string | UnexpectedError>>>();
+    expectTypeOf(r2).toEqualTypeOf<Promise<Result<number, string | UnhandledException>>>();
 
     const r3 = p3.run("abc");
-    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, UnexpectedError>>>();
+    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
 
-    expect((await p1.run()).ok).toBe(true);
+    expect((await p1.run()).isOk()).toBe(true);
 
     // @ts-expect-error - nullary retry op does not accept args
     p1.run(1);
@@ -336,8 +336,8 @@ describe("type inference", () => {
     const p1 = fromGenFn(function* (id: string) {
       return yield* _try(() => Promise.resolve(id.length));
     }).withRetry();
-    expectTypeOf(p1).toEqualTypeOf<Op<number, UnexpectedError, [id: string]>>();
-    expectTypeOf(p1.run("abc")).toEqualTypeOf<Promise<Result<number, UnexpectedError>>>();
+    expectTypeOf(p1).toEqualTypeOf<Op<number, UnhandledException, [id: string]>>();
+    expectTypeOf(p1.run("abc")).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
 
     const p2 = fromGenFn(function* (id: string) {
       if (Math.random() < 0) {
@@ -346,9 +346,11 @@ describe("type inference", () => {
       return id.length;
     }).withRetry();
     expectTypeOf(p2).toEqualTypeOf<Op<number, string, [id: string]>>();
-    expectTypeOf(p2.run("abc")).toEqualTypeOf<Promise<Result<number, string | UnexpectedError>>>();
+    expectTypeOf(p2.run("abc")).toEqualTypeOf<
+      Promise<Result<number, string | UnhandledException>>
+    >();
 
-    expect((await p1.run("abcd")).ok).toBe(true);
+    expect((await p1.run("abcd")).isOk()).toBe(true);
   });
 
   test("distinguishes between multiple error types", async () => {
@@ -359,7 +361,7 @@ describe("type inference", () => {
     class CustomError2 extends Error {
       readonly alsoUnique = "CustomError2";
     }
-    class CustomError3 extends TypedError("CustomError3") {}
+    class CustomError3 extends TaggedError("CustomError3")() {}
     const alwaysFails1 = fromGenFn(function* () {
       if (Math.random() < 0) {
         return yield* succeed(1);
@@ -385,13 +387,13 @@ describe("type inference", () => {
       return a + b + c;
     });
     const result = await program.run();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBeInstanceOf(CustomError1);
   });
 
   test("withTimeout preserves inferred op shapes", async () => {
     const p1 = _try(() => Promise.resolve(1)).withTimeout(10);
-    expectTypeOf(p1).toEqualTypeOf<Op<number, UnexpectedError | TimeoutError, []>>();
+    expectTypeOf(p1).toEqualTypeOf<Op<number, UnhandledException | TimeoutError, []>>();
 
     const p2 = _try(
       () => Promise.resolve(1),
@@ -405,17 +407,17 @@ describe("type inference", () => {
     expectTypeOf(p3).toEqualTypeOf<Op<number, TimeoutError, [id: string]>>();
 
     const r1 = p1.run();
-    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, TimeoutError | UnexpectedError>>>();
+    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, TimeoutError | UnhandledException>>>();
 
     const r2 = p2.run();
     expectTypeOf(r2).toEqualTypeOf<
-      Promise<Result<number, string | TimeoutError | UnexpectedError>>
+      Promise<Result<number, string | TimeoutError | UnhandledException>>
     >();
 
     const r3 = p3.run("abc");
-    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, TimeoutError | UnexpectedError>>>();
+    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, TimeoutError | UnhandledException>>>();
 
-    expect((await p1.run()).ok).toBe(true);
+    expect((await p1.run()).isOk()).toBe(true);
 
     // @ts-expect-error - nullary timeout op does not accept args
     p1.run(1);
@@ -425,7 +427,7 @@ describe("type inference", () => {
     p3.run("abc", "extra");
 
     let attempts = 0;
-    class FetchError extends TypedError("FetchError") {}
+    class FetchError extends TaggedError("FetchError")() {}
     const fetcher = async () => {
       attempts++;
       if (attempts === 1) {
@@ -447,9 +449,9 @@ describe("type inference", () => {
     expectTypeOf(p4).toEqualTypeOf<Op<number, TimeoutError | FetchError, []>>();
     const result = await p4.run();
     expectTypeOf(result).toEqualTypeOf<
-      Result<number, TimeoutError | FetchError | UnexpectedError>
+      Result<number, TimeoutError | FetchError | UnhandledException>
     >();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBeInstanceOf(TimeoutError);
   });
 });

--- a/src/builders.test.ts
+++ b/src/builders.test.ts
@@ -378,7 +378,7 @@ describe("type inference", () => {
       if (Math.random() < 0) {
         return yield* succeed(1);
       }
-      return yield* fail(new CustomError3());
+      return yield* new CustomError3();
     });
     const program = fromGenFn(function* () {
       const a = yield* alwaysFails1();

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,4 +1,4 @@
-import { UnexpectedError, UnreachableError } from "./errors.js";
+import { UnhandledException, UnreachableError } from "./errors.js";
 import { type FromGenFn, type Instruction, type Op, runOp } from "./core.js";
 import { withRetryOp, withTimeoutOp, withSignalOp, type RetryPolicy } from "./policies.js";
 import { err, ok, type Result } from "./result.js";
@@ -19,7 +19,7 @@ export const succeed = <T>(value: T): Op<Awaited<T>, never, []> => {
     withRetry: (policy?: RetryPolicy) => withRetryOp(self as never, policy),
     withTimeout: (timeoutMs: number) => withTimeoutOp(self as never, timeoutMs),
     withSignal: (signal: AbortSignal) => withSignalOp(self as never, signal),
-    type: "Op",
+    _tag: "Op",
   };
   const op = () => self;
   return Object.assign(op, self) as never;
@@ -38,7 +38,7 @@ export const fail = <E>(value: E): Op<never, E, readonly []> => {
     withRetry: (policy?: RetryPolicy) => withRetryOp(self as never, policy),
     withTimeout: (timeoutMs: number) => withTimeoutOp(self as never, timeoutMs),
     withSignal: (signal: AbortSignal) => withSignalOp(self as never, signal),
-    type: "Op" as const,
+    _tag: "Op" as const,
   };
   const op = () => self;
   return Object.assign(op, self) as never;
@@ -47,23 +47,23 @@ export const fail = <E>(value: E): Op<never, E, readonly []> => {
 /**
  * Suspends until a promise settles, then continues with its value or a mapped failure.
  */
-export const _try = <T, E = UnexpectedError>(
+export const _try = <T, E = UnhandledException>(
   f: (signal: AbortSignal) => T,
   onError?: (e: unknown) => E,
 ): Op<Awaited<T>, E, readonly []> => {
   const self = {
     *[Symbol.iterator]() {
       const result: Result<T, E> = yield {
-        type: "Suspended" as const,
+        _tag: "Suspended" as const,
         suspend: (signal: AbortSignal) =>
           Promise.resolve()
             .then(() => f(signal))
             .then(
               (a) => ok(a),
-              (cause) => err(onError ? onError(cause) : new UnexpectedError(cause)),
+              (cause) => err(onError ? onError(cause) : new UnhandledException({ cause })),
             ) as Promise<Result<T, E>>,
       };
-      if (result.type === "Err") {
+      if (result.isErr()) {
         yield result;
         throw new UnreachableError();
       }
@@ -73,7 +73,7 @@ export const _try = <T, E = UnexpectedError>(
     withRetry: (policy?: RetryPolicy) => withRetryOp(self as never, policy),
     withTimeout: (timeoutMs: number) => withTimeoutOp(self as never, timeoutMs),
     withSignal: (signal: AbortSignal) => withSignalOp(self as never, signal),
-    type: "Op" as const,
+    _tag: "Op" as const,
   };
   const op = () => self;
   return Object.assign(op, self) as never;
@@ -92,7 +92,7 @@ export const fromGenFn: FromGenFn = (
       withRetry: (policy?: RetryPolicy) => withRetryOp(inner as never, policy),
       withTimeout: (timeoutMs: number) => withTimeoutOp(inner as never, timeoutMs),
       withSignal: (signal: AbortSignal) => withSignalOp(inner as never, signal),
-      type: "Op",
+      _tag: "Op",
     };
     const _op = () => inner;
     return Object.assign(_op, inner);
@@ -102,7 +102,7 @@ export const fromGenFn: FromGenFn = (
     withRetry: (policy?: RetryPolicy) => withRetryOp(out as never, policy),
     withTimeout: (timeoutMs: number) => withTimeoutOp(out as never, timeoutMs),
     withSignal: (signal: AbortSignal) => withSignalOp(out as never, signal),
-    type: "Op" as const,
+    _tag: "Op" as const,
   }) as never;
 
   return out as Op<unknown, unknown, []> | Op<unknown, unknown, readonly unknown[]>;

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -1,7 +1,7 @@
-import { ErrorGroup, UnexpectedError, UnreachableError } from "./errors.js";
+import { ErrorGroup, UnhandledException, UnreachableError } from "./errors.js";
 import { drive, makeNullaryOp, type Instruction, type Op } from "./core.js";
 import { withRetryOp, withTimeoutOp, withSignalOp, type RetryPolicy } from "./policies.js";
-import { err, ok, type Err, type Result } from "./result.js";
+import { err, ok, type Result } from "./result.js";
 
 type NullaryOp = Op<unknown, unknown, readonly []>;
 type SuccessOf<O> = O extends Op<infer T, unknown, readonly []> ? T : never;
@@ -23,7 +23,7 @@ const fanOut = <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
 ): {
-  runs: readonly Promise<Result<T, E | UnexpectedError>>[];
+  runs: readonly Promise<Result<T, E | UnhandledException>>[];
   controllers: readonly AbortController[];
   detach: () => void;
 } => {
@@ -52,17 +52,17 @@ export const allOp = <const Ops extends readonly NullaryOp[]>(
   concurrency?: number,
 ): Op<
   { [K in keyof Ops]: SuccessOf<Ops[K]> },
-  ErrorOf<Ops[number]> | UnexpectedError,
+  ErrorOf<Ops[number]> | UnhandledException,
   readonly []
 > => {
   const snapshot = ops.slice();
   const limit = concurrencyLimit(concurrency, snapshot.length);
   return makeCombinatorOp(function* () {
     const result = (yield {
-      type: "Suspended" as const,
+      _tag: "Suspended" as const,
       suspend: (outerSignal) => driveAll(snapshot, outerSignal, limit),
     }) as Result<never, never>;
-    if (!result.ok) {
+    if (result.isErr()) {
       yield err(result.error);
       throw new UnreachableError();
     }
@@ -74,11 +74,11 @@ const driveAll = async <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
   concurrency: number,
-): Promise<Result<T[], E | UnexpectedError>> => {
+): Promise<Result<T[], E | UnhandledException>> => {
   if (ops.length === 0) return ok([]);
   if (concurrency >= ops.length) return driveAllUnbounded(ops, outerSignal);
 
-  const results: (Result<T, E | UnexpectedError> | undefined)[] = new Array(ops.length);
+  const results: (Result<T, E | UnhandledException> | undefined)[] = new Array(ops.length);
   const controllers = new Set<AbortController>();
   const cascade = () => {
     for (const c of controllers) c.abort(outerSignal.reason);
@@ -87,7 +87,7 @@ const driveAll = async <T, E>(
   else outerSignal.addEventListener("abort", cascade, { once: true });
 
   let nextIndex = 0;
-  let firstErr: Err<E | UnexpectedError> | undefined;
+  let firstErr: (E | UnhandledException) | undefined;
 
   const worker = async () => {
     while (firstErr === undefined) {
@@ -103,8 +103,8 @@ const driveAll = async <T, E>(
       controllers.delete(controller);
       results[i] = res;
 
-      if (!res.ok && firstErr === undefined) {
-        firstErr = res;
+      if (res.isErr() && firstErr === undefined) {
+        firstErr = res.error;
         for (const c of controllers) c.abort();
       }
     }
@@ -116,24 +116,24 @@ const driveAll = async <T, E>(
     outerSignal.removeEventListener("abort", cascade);
   }
 
-  if (firstErr !== undefined) return firstErr;
+  if (firstErr !== undefined) return err(firstErr);
   const values: T[] = [];
-  for (const r of results) if (r?.ok) values.push(r.value);
+  for (const r of results) if (r?.isOk()) values.push(r.value);
   return ok(values);
 };
 
 const driveAllUnbounded = async <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
-): Promise<Result<T[], E | UnexpectedError>> => {
+): Promise<Result<T[], E | UnhandledException>> => {
   const { runs, controllers, detach } = fanOut(ops, outerSignal);
 
-  let firstErr: Err<E | UnexpectedError> | undefined;
+  let firstErr: (E | UnhandledException) | undefined;
 
   const observed = runs.map((p, i) =>
     p.then((res) => {
-      if (!res.ok && firstErr === undefined) {
-        firstErr = res;
+      if (res.isErr() && firstErr === undefined) {
+        firstErr = res.error;
         controllers.forEach((c, j) => {
           if (j !== i) c.abort();
         });
@@ -145,9 +145,9 @@ const driveAllUnbounded = async <T, E>(
   const results = await Promise.all(observed);
   detach();
 
-  if (firstErr !== undefined) return firstErr;
+  if (firstErr !== undefined) return err(firstErr);
   const values: T[] = [];
-  for (const r of results) if (r.ok) values.push(r.value);
+  for (const r of results) if (r.isOk()) values.push(r.value);
   return ok(values);
 };
 
@@ -155,16 +155,16 @@ export const allSettledOp = <const Ops extends readonly NullaryOp[]>(
   ops: Ops,
   concurrency?: number,
 ): Op<
-  { [K in keyof Ops]: Result<SuccessOf<Ops[K]>, ErrorOf<Ops[K]> | UnexpectedError> },
+  { [K in keyof Ops]: Result<SuccessOf<Ops[K]>, ErrorOf<Ops[K]> | UnhandledException> },
   never,
   readonly []
 > => {
   const snapshot = ops.slice();
   const limit = concurrencyLimit(concurrency, snapshot.length);
-  type V = { [K in keyof Ops]: Result<SuccessOf<Ops[K]>, ErrorOf<Ops[K]> | UnexpectedError> };
+  type V = { [K in keyof Ops]: Result<SuccessOf<Ops[K]>, ErrorOf<Ops[K]> | UnhandledException> };
   return makeCombinatorOp<V, never>(function* (): Generator<Instruction<never>, V, unknown> {
     const value = (yield {
-      type: "Suspended" as const,
+      _tag: "Suspended" as const,
       suspend: (outerSignal) => driveAllSettled(snapshot, outerSignal, limit),
     }) as V;
     return value;
@@ -173,12 +173,12 @@ export const allSettledOp = <const Ops extends readonly NullaryOp[]>(
 
 export const settleOp = <T, E>(
   op: Op<T, E, readonly []>,
-): Op<Result<T, E | UnexpectedError>, never, readonly []> => {
-  return makeCombinatorOp<Result<T, E | UnexpectedError>, never>(function* () {
+): Op<Result<T, E | UnhandledException>, never, readonly []> => {
+  return makeCombinatorOp<Result<T, E | UnhandledException>, never>(function* () {
     const value = (yield {
-      type: "Suspended" as const,
+      _tag: "Suspended" as const,
       suspend: (outerSignal) => drive(op, outerSignal),
-    }) as Result<T, E | UnexpectedError>;
+    }) as Result<T, E | UnhandledException>;
     return value;
   });
 };
@@ -187,11 +187,11 @@ const driveAllSettled = async <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
   concurrency: number,
-): Promise<Result<T, E | UnexpectedError>[]> => {
+): Promise<Result<T, E | UnhandledException>[]> => {
   if (ops.length === 0) return [];
   if (concurrency >= ops.length) return driveAllSettledUnbounded(ops, outerSignal);
 
-  const results: (Result<T, E | UnexpectedError> | undefined)[] = new Array(ops.length);
+  const results: (Result<T, E | UnhandledException> | undefined)[] = new Array(ops.length);
   const controllers = new Set<AbortController>();
   const cascade = () => {
     for (const c of controllers) c.abort(outerSignal.reason);
@@ -221,13 +221,13 @@ const driveAllSettled = async <T, E>(
     outerSignal.removeEventListener("abort", cascade);
   }
 
-  return results.filter((r): r is Result<T, E | UnexpectedError> => r !== undefined);
+  return results.filter((r): r is Result<T, E | UnhandledException> => r !== undefined);
 };
 
 const driveAllSettledUnbounded = async <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
-): Promise<Result<T, E | UnexpectedError>[]> => {
+): Promise<Result<T, E | UnhandledException>[]> => {
   const fan = fanOut(ops, outerSignal);
   const results = await Promise.all(fan.runs);
   fan.detach();
@@ -236,16 +236,20 @@ const driveAllSettledUnbounded = async <T, E>(
 
 export const anyOp = <const Ops extends readonly NullaryOp[]>(
   ops: Ops,
-): Op<SuccessOf<Ops[number]>, ErrorGroup<ErrorOf<Ops[number]> | UnexpectedError>, readonly []> => {
+): Op<
+  SuccessOf<Ops[number]>,
+  ErrorGroup<ErrorOf<Ops[number]> | UnhandledException>,
+  readonly []
+> => {
   const snapshot = ops.slice();
   type V = SuccessOf<Ops[number]>;
-  type E = ErrorGroup<ErrorOf<Ops[number]> | UnexpectedError>;
+  type E = ErrorGroup<ErrorOf<Ops[number]> | UnhandledException>;
   return makeCombinatorOp<V, E>(function* (): Generator<Instruction<E>, V, unknown> {
     const result = (yield {
-      type: "Suspended" as const,
+      _tag: "Suspended" as const,
       suspend: (outerSignal) => driveAny(snapshot, outerSignal),
     }) as Result<V, E>;
-    if (!result.ok) {
+    if (result.isErr()) {
       yield err(result.error);
       throw new UnreachableError();
     }
@@ -256,18 +260,18 @@ export const anyOp = <const Ops extends readonly NullaryOp[]>(
 const driveAny = <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
-): Promise<Result<T, ErrorGroup<E | UnexpectedError>>> => {
+): Promise<Result<T, ErrorGroup<E | UnhandledException>>> => {
   if (ops.length === 0) {
     return Promise.resolve(err(new ErrorGroup([], "Op.any requires at least one operation")));
   }
   const fan = fanOut(ops, outerSignal);
 
-  return new Promise<Result<T, ErrorGroup<E | UnexpectedError>>>((resolve) => {
+  return new Promise<Result<T, ErrorGroup<E | UnhandledException>>>((resolve) => {
     let winnerDecided = false;
 
     const observed = fan.runs.map((p, i) =>
       p.then((res) => {
-        if (!winnerDecided && res.ok) {
+        if (!winnerDecided && res.isOk()) {
           winnerDecided = true;
           fan.controllers.forEach((c, j) => {
             if (j !== i) c.abort();
@@ -282,8 +286,8 @@ const driveAny = <T, E>(
     Promise.all(observed).then((results) => {
       if (winnerDecided) return;
       fan.detach();
-      const errors: (E | UnexpectedError)[] = [];
-      for (const r of results) if (!r.ok) errors.push(r.error);
+      const errors: (E | UnhandledException)[] = [];
+      for (const r of results) if (r.isErr()) errors.push(r.error);
       resolve(err(new ErrorGroup(errors, "Op.any failed because all operations failed")));
     });
   });
@@ -291,16 +295,16 @@ const driveAny = <T, E>(
 
 export const raceOp = <const Ops extends readonly NullaryOp[]>(
   ops: Ops,
-): Op<SuccessOf<Ops[number]>, ErrorOf<Ops[number]> | UnexpectedError, readonly []> => {
+): Op<SuccessOf<Ops[number]>, ErrorOf<Ops[number]> | UnhandledException, readonly []> => {
   const snapshot = ops.slice();
   type V = SuccessOf<Ops[number]>;
-  type E = ErrorOf<Ops[number]> | UnexpectedError;
+  type E = ErrorOf<Ops[number]> | UnhandledException;
   return makeCombinatorOp<V, E>(function* (): Generator<Instruction<E>, V, unknown> {
     const result = (yield {
-      type: "Suspended" as const,
+      _tag: "Suspended" as const,
       suspend: (outerSignal) => driveRace(snapshot, outerSignal),
     }) as Result<V, E>;
-    if (!result.ok) {
+    if (result.isErr()) {
       yield err(result.error);
       throw new UnreachableError();
     }
@@ -311,9 +315,11 @@ export const raceOp = <const Ops extends readonly NullaryOp[]>(
 const driveRace = <T, E>(
   ops: readonly Op<T, E, readonly []>[],
   outerSignal: AbortSignal,
-): Promise<Result<T, E | UnexpectedError>> => {
+): Promise<Result<T, E | UnhandledException>> => {
   if (ops.length === 0) {
-    return Promise.resolve(err(new UnexpectedError("Op.race requires at least one operation")));
+    return Promise.resolve(
+      err(new UnhandledException({ cause: new Error("Op.race requires at least one operation") })),
+    );
   }
   const { runs, controllers, detach } = fanOut(ops, outerSignal);
 

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test, assert } from "vitest";
 import { fail, fromGenFn, succeed, _try } from "./builders.js";
-import { UnexpectedError } from "./errors.js";
+import { UnhandledException } from "./errors.js";
 
 describe("op.run", () => {
   test("sync op completes without awaiting", async () => {
     const result = await succeed("sync").run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe("sync");
   });
 
@@ -14,7 +14,7 @@ describe("op.run", () => {
       () => Promise.resolve("async"),
       () => "err",
     ).run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe("async");
   });
 
@@ -31,12 +31,12 @@ describe("op.run", () => {
       return { first, second };
     });
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value.first).toEqual({ data: "raw" });
     expect(result.value.second).toEqual({ n: 69 });
   });
 
-  test("UnexpectedError propagates from rejecting promise", async () => {
+  test("UnhandledException propagates from rejecting promise", async () => {
     const error = new Error("unhandled");
     const makeNumber = fromGenFn(function* (n: number) {
       return n;
@@ -50,8 +50,8 @@ describe("op.run", () => {
       return x;
     });
     const result = await program.run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(result.error.cause).toBeInstanceOf(Error);
     expect(result.error.cause).toBe(error);
   });
@@ -60,54 +60,63 @@ describe("op.run", () => {
 describe("edge cases and invariants", () => {
   test("Ok result has correct shape", async () => {
     const result = await succeed(1).run();
-    assert(result.ok === true, "result.ok should be true");
-    expect(result.type).toBe("Ok");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(1);
   });
 
   test("Err result has correct shape", async () => {
     const result = await fail("e").run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.type).toBe("Err");
+    assert(result.isErr() === true, "should be Err");
     expect(result.error).toBe("e");
   });
 
   test("result from run is frozen", async () => {
     const okResult = await succeed(1).run();
-    expect(okResult.ok).toBe(true);
-    expect(Object.isFrozen(okResult)).toBe(true);
+    expect(okResult.isOk()).toBe(true);
+    expect(Object.isFrozen(okResult)).toBe(false);
 
     const errResult = await fail("e").run();
-    assert(errResult.ok === false, "errResult.ok should be false");
-    expect(Object.isFrozen(errResult)).toBe(true);
+    assert(errResult.isErr() === true, "should be Err");
+    expect(Object.isFrozen(errResult)).toBe(false);
   });
 
   test("empty and zero values work correctly", async () => {
     const r0 = await succeed(0).run();
-    assert(r0.ok === true, "r0.ok should be true");
+    assert(r0.isOk() === true, "should be Ok");
     expect(r0.value).toBe(0);
 
     const rEmpty = await succeed("").run();
-    assert(rEmpty.ok === true, "rEmpty.ok should be true");
+    assert(rEmpty.isOk() === true, "should be Ok");
     expect(rEmpty.value).toBe("");
   });
 
-  test("returns UnexpectedError when throw in generator", async () => {
+  test("returns UnhandledException when throw in generator", async () => {
     const error = new Error("unhandled");
     const result = await fromGenFn(function* () {
       throw error;
     }).run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(result.error.cause).toBe(error);
   });
-  test("returns UnexpectedError when unhandled Promise rejection in gen", async () => {
+
+  test("returns UnhandledException when generator yields invalid instruction", async () => {
+    const result = await fromGenFn(function* () {
+      yield { _tag: "NotAnInstruction" } as unknown as never;
+      return 1;
+    }).run();
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
+    expect(result.error.cause).toBeInstanceOf(TypeError);
+  });
+
+  test("returns UnhandledException when unhandled Promise rejection in gen", async () => {
     const error = new Error("unhandled");
     const result = await fromGenFn(function* () {
       return Promise.reject(error);
     }).run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(result.error.cause).toBe(error);
   });
 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,14 +1,14 @@
-import { UnexpectedError, type TimeoutError } from "./errors.js";
+import { UnhandledException, type TimeoutError } from "./errors.js";
 import { err, ok, type Result, type Err, type ExtractErr } from "./result.js";
 import type { RetryPolicy } from "./policies.js";
 import type { Typed } from "./typed.js";
 
 export interface Suspended {
-  readonly type: "Suspended";
+  readonly _tag: "Suspended";
   readonly suspend: (signal: AbortSignal) => Promise<unknown>;
 }
 
-export type Instruction<E> = Err<E> | Suspended;
+export type Instruction<E> = Err<unknown, E> | Suspended;
 
 export interface WithRetry<T, E, A extends readonly unknown[]> {
   withRetry(policy?: RetryPolicy): Op<T, E, A>;
@@ -23,50 +23,70 @@ export interface WithSignal<T, E, A extends readonly unknown[]> {
 }
 
 export interface OpBase<T, E> {
-  type: "Op";
+  readonly _tag: "Op";
   [Symbol.iterator](): Generator<Instruction<E>, T, unknown>;
 }
 
 export interface OpNullary<T, E>
   extends OpBase<T, E>, WithRetry<T, E, []>, WithTimeout<T, E, []>, WithSignal<T, E, []> {
   (): OpBase<T, E>;
-  run(): Promise<Result<T, E | UnexpectedError>>;
+  run(): Promise<Result<T, E | UnhandledException>>;
 }
 
 export interface OpArity<T, E, A extends readonly unknown[]>
   extends WithRetry<T, E, A>, WithTimeout<T, E, A>, WithSignal<T, E, A> {
   (...args: A): OpNullary<T, E>;
-  run(...args: A): Promise<Result<T, E | UnexpectedError>>;
+  run(...args: A): Promise<Result<T, E | UnhandledException>>;
 }
 
 type _Op<T, E, A extends readonly unknown[]> = [] extends A ? OpNullary<T, E> : OpArity<T, E, A>;
 
 export type Op<T, E, A extends readonly unknown[]> = _Op<T, E, A> & Typed<"Op">;
 
-export function runOp<T, E>(op: Op<T, E, readonly []>): Promise<Result<T, E | UnexpectedError>> {
+export function runOp<T, E>(op: Op<T, E, readonly []>): Promise<Result<T, E | UnhandledException>> {
   return drive(op, new AbortController().signal);
+}
+
+function isSuspended(value: unknown): value is Suspended {
+  return (
+    typeof value === "object" && value !== null && "_tag" in value && value._tag === "Suspended"
+  );
+}
+
+function isErrInstruction<E>(value: unknown): value is Err<unknown, E> {
+  if (typeof value !== "object" || value === null || !("isErr" in value)) return false;
+  const hasIsErr = value as { isErr?: unknown };
+  return typeof hasIsErr.isErr === "function" && hasIsErr.isErr();
 }
 
 export async function drive<T, E>(
   op: Op<T, E, readonly []>,
   signal: AbortSignal,
-): Promise<Result<T, E | UnexpectedError>> {
+): Promise<Result<T, E | UnhandledException>> {
   try {
     const ef = typeof op === "function" ? op() : op;
     const iter = ef[Symbol.iterator]();
     let step = iter.next();
     while (!step.done) {
       try {
-        if (step.value.type === "Err") return err(step.value.error);
-        step = iter.next(await step.value.suspend(signal));
+        if (isSuspended(step.value)) {
+          step = iter.next(await step.value.suspend(signal));
+          continue;
+        }
+        if (isErrInstruction<E>(step.value)) return err(step.value.error);
+        return err(
+          new UnhandledException({
+            cause: new TypeError("Op generator yielded an invalid instruction"),
+          }),
+        );
       } catch (cause) {
-        return err(new UnexpectedError(cause));
+        return err(new UnhandledException({ cause }));
       }
     }
     const value = await step.value;
     return ok(value);
   } catch (cause) {
-    return err(new UnexpectedError(cause));
+    return err(new UnhandledException({ cause }));
   }
 }
 
@@ -96,7 +116,7 @@ export const makeNullaryOp = <T, E>(
     withRetry: hooks.withRetry,
     withTimeout: hooks.withTimeout,
     withSignal: hooks.withSignal,
-    type: "Op" as const,
+    _tag: "Op" as const,
   };
   const op = () => self;
   return Object.assign(op, self) as never;

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,132 +1,26 @@
-import { describe, expect, test, assert, expectTypeOf } from "vitest";
-import { fromGenFn } from "./builders.js";
-import type { Op } from "./core.js";
-import { UnexpectedError, TypedError } from "./errors.js";
+import { describe, expect, test } from "vitest";
+import { UnhandledException } from "./errors.js";
 
-describe("UnexpectedError", () => {
-  test("creates error with message 'An unexpected error occurred'", () => {
-    const err = new UnexpectedError("test");
-    expect(err.message).toBe("An unexpected error occurred");
+describe("UnhandledException", () => {
+  test("derives message from cause", () => {
+    const err = new UnhandledException({ cause: new Error("test") });
+    expect(err.message).toBe("Unhandled exception: test");
   });
 
   test("accepts and preserves cause in constructor options", () => {
     const cause = new Error("original");
-    const err = new UnexpectedError(cause);
+    const err = new UnhandledException({ cause });
     expect(err.cause).toBe(cause);
   });
 
-  test("type discriminant is 'UnexpectedError'", () => {
-    const err = new UnexpectedError(null);
-    expect(err.type).toBe("UnexpectedError");
+  test("type discriminant is 'UnhandledException'", () => {
+    const err = new UnhandledException({ cause: null });
+    expect(err._tag).toBe("UnhandledException");
   });
 
-  test("instanceof Error and UnexpectedError", () => {
-    const err = new UnexpectedError("x");
+  test("instanceof Error and UnhandledException", () => {
+    const err = new UnhandledException({ cause: new Error("x") });
     expect(err).toBeInstanceOf(Error);
-    expect(err).toBeInstanceOf(UnexpectedError);
-  });
-});
-
-describe("TypedError", () => {
-  test("default message uses the type name", () => {
-    const NetworkError = TypedError("NetworkError", "A network error occurred");
-    const err = new NetworkError();
-    expect(err.message).toBe("A network error occurred");
-    expect(err.type).toBe("NetworkError");
-  });
-
-  test("subclass with no extra data can be constructed with no arguments", () => {
-    class DivisionByZeroError extends TypedError("DivisionByZeroError") {}
-    const err = new DivisionByZeroError();
-    expect(err.message).toBe("");
-    expect(err).toBeInstanceOf(Error);
-    expect(err).toBeInstanceOf(DivisionByZeroError);
-  });
-
-  test("custom message overrides default and is not left on data", () => {
-    const ValidationError = TypedError("ValidationError");
-    const err = new ValidationError({ message: "field required" });
-    expect(err.message).toBe("field required");
-  });
-
-  test("message key with undefined falls back to default text", () => {
-    const E = TypedError("E", "An E error occurred");
-    const err = new E({ message: undefined });
-    expect(err.message).toBe("An E error occurred");
-  });
-
-  test("cause is passed to Error and stripped from data", () => {
-    const E = TypedError("E");
-    const cause = new Error("root");
-    const err = new E({ cause });
-    expect(err.cause).toBe(cause);
-  });
-
-  test("preserves arbitrary payload fields on data", () => {
-    class NotFound extends TypedError("NotFound")<{
-      resource: string;
-      id: number;
-    }> {}
-    const err = new NotFound({ resource: "user", id: 69, message: "gone", cause: "db" });
-    expect(err.message).toBe("gone");
-    expect(err.cause).toBe("db");
-    expect(err.resource).toBe("user");
-    expect(err.id).toBe(69);
-  });
-
-  test("does not mutate the passed data object, creates a new object without message and cause", () => {
-    const E = TypedError("E");
-    const payload = Object.freeze({ message: "m", cause: 1, extra: true });
-    const err = new E(payload);
-    expect(err).toHaveProperty("extra", true);
-  });
-
-  test("does not allow payload to override core fields or prototype", () => {
-    const E = TypedError("E");
-    const payload = {
-      type: "OverriddenType",
-      name: "OverriddenName",
-      stack: "spoofed",
-      __proto__: { poisoned: true },
-      safe: "ok",
-    } as unknown as Record<string, unknown>;
-
-    const err = new E(payload);
-
-    expect(err.type).toBe("E");
-    expect(err.name).toBe("E");
-    expect(err.stack).not.toBe("spoofed");
-    expect(Object.getPrototypeOf(err)).toBe(E.prototype);
-    expect(err).toHaveProperty("safe", "ok");
-    expect(Object.prototype.hasOwnProperty.call(err, "poisoned")).toBe(false);
-  });
-
-  test("type narrowing: distinct factories produce distinct classes", () => {
-    const A = TypedError("A");
-    const B = TypedError("B");
-    const a = new A();
-    const b = new B();
-    expect(a).toBeInstanceOf(A);
-    expect(a).not.toBeInstanceOf(B);
-    expect(b).toBeInstanceOf(B);
-    expect(b).not.toBeInstanceOf(A);
-  });
-
-  test("expectTypeOf: default data allows zero-arg constructor", () => {
-    const E = TypedError("E");
-    const e = new E();
-    expectTypeOf(e).toEqualTypeOf<TypedError<"E">>();
-  });
-
-  test("can be used directly in gen", async () => {
-    class CustomError extends TypedError("CustomError") {}
-    const customError = new CustomError();
-    const e = fromGenFn(function* () {
-      return yield* customError;
-    });
-    expectTypeOf(e).toEqualTypeOf<Op<never, CustomError, []>>();
-    const result = await e.run();
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBe(customError);
+    expect(err).toBeInstanceOf(UnhandledException);
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,98 +1,17 @@
 import type { Err } from "./result.js";
 import { err } from "./result.js";
 import type { Typed } from "./typed.js";
+import { TaggedError, UnhandledException } from "better-result";
 
-const blockedTypedErrorDataKeys = new Set([
-  "__proto__",
-  "prototype",
-  "constructor",
-  "type",
-  "name",
-  "stack",
-]);
-
-function attachTypedErrorData(target: Error, data: Record<string, unknown>): void {
-  for (const [key, value] of Object.entries(data)) {
-    if (blockedTypedErrorDataKeys.has(key)) {
-      continue;
-    }
-    Object.defineProperty(target, key, {
-      value,
-      enumerable: true,
-      configurable: true,
-      writable: true,
-    });
-  }
-}
-
-/**
- * Instance type for classes created by {@link TypedError}.
- */
-export type TypedError<
-  TypeName extends string,
-  Data extends Record<string, unknown> & { message?: string | undefined; cause?: unknown } = {},
-> = _TypedError<TypeName> & ({} extends Data ? {} : { [K in keyof Data]: Data[K] });
-interface _TypedError<TypeName extends string> extends Error {
-  readonly type: TypeName;
-  [Symbol.iterator](): Generator<Err<this>, never, unknown>;
-}
-
-type WithDefaultErrorData<T> = T & { message?: string | undefined; cause?: unknown };
-
-type TypedErrorCtorParams<Data extends WithDefaultErrorData<Record<string, unknown>>> =
-  {} extends Data ? [data?: WithDefaultErrorData<{}>] : [data: WithDefaultErrorData<Data>];
-
-export interface TypedErrorConstructor<TypeName extends string> {
-  new (data?: WithDefaultErrorData<{}>): TypedError<TypeName, {}>;
-  new <Data extends WithDefaultErrorData<Record<string, unknown>>>(
-    data: WithDefaultErrorData<Data>,
-  ): TypedError<TypeName, Data>;
-}
-
-/**
- * Creates a new typed error class with the given type name and optional default message.
- */
-export function TypedError<TType extends string>(
-  type: TType,
-  defaultMessage?: string,
-): TypedErrorConstructor<TType> {
-  return class<Data extends WithDefaultErrorData<Record<string, unknown>> = {}>
-    extends Error
-    implements Typed<TType>
-  {
-    readonly type = type;
-
-    constructor(...args: TypedErrorCtorParams<Data>) {
-      const _data = args[0] ?? ({} as Data);
-      const { message, cause, ...data } = _data;
-      super(message ?? defaultMessage, { cause });
-      this.name = type;
-      attachTypedErrorData(this, data);
-    }
-
-    *[Symbol.iterator](): Generator<Err<this>, never, unknown> {
-      yield err(this);
-      throw new UnreachableError();
-    }
-  };
-}
-TypedError.is = (error: unknown): error is TypedError<string> => {
-  return error instanceof Error && "type" in error && typeof error.type === "string";
-};
-
-/**
- * Built-in typed error for failures that are not mapped to a domain-specific error.
- */
-export class UnexpectedError extends TypedError("UnexpectedError") {
-  constructor(cause: unknown, message?: string) {
-    super({ cause, message: message ?? "An unexpected error occurred" });
-  }
-}
+export { TaggedError, UnhandledException };
 
 /**
  * Built-in typed error emitted when an operation exceeds a timeout budget.
  */
-export class TimeoutError extends TypedError("TimeoutError")<{ timeoutMs: number }> {
+export class TimeoutError extends TaggedError("TimeoutError")<{
+  message: string;
+  timeoutMs: number;
+}>() {
   constructor({ timeoutMs }: { timeoutMs: number }) {
     super({ message: `Operation timed out after ${timeoutMs}ms`, timeoutMs });
   }
@@ -101,7 +20,11 @@ export class TimeoutError extends TypedError("TimeoutError")<{ timeoutMs: number
 /**
  * Internal control-flow sentinel used to mark logically impossible paths.
  */
-export class UnreachableError extends TypedError("UnreachableError", "Unreachable code path") {}
+export class UnreachableError extends TaggedError("UnreachableError")<{ message: string }>() {
+  constructor() {
+    super({ message: "Unreachable code path" });
+  }
+}
 
 interface ErrorGroupConstructor {
   new <E>(errors: Iterable<E>, message: string): ErrorGroup<E>;
@@ -113,7 +36,7 @@ interface ErrorGroupConstructor {
  */
 export interface ErrorGroup<E> extends AggregateError, Typed<"ErrorGroup"> {
   readonly errors: E[];
-  [Symbol.iterator](): Generator<Err<this>, never, unknown>;
+  [Symbol.iterator](): Generator<Err<never, this>, never, unknown>;
 }
 
 /**
@@ -123,15 +46,15 @@ export const ErrorGroup: ErrorGroupConstructor = class<E>
   extends AggregateError
   implements Typed<"ErrorGroup">
 {
-  readonly type = "ErrorGroup";
+  readonly _tag = "ErrorGroup";
   override readonly errors: E[];
   constructor(errors: Iterable<E>, message: string) {
     super(errors, message);
     this.errors = Array.from(errors);
-    this.name = this.type;
+    this.name = this._tag;
   }
 
-  *[Symbol.iterator](): Generator<Err<this>, never, unknown> {
+  *[Symbol.iterator](): Generator<Err<never, this>, never, unknown> {
     yield err(this);
     throw new UnreachableError();
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -369,7 +369,7 @@ describe("public API (index)", () => {
   });
 
   describe("Op namespace value", () => {
-    test("Op.type is 'OpFactory'", () => {
+    test("Op._tag is 'OpFactory'", () => {
       expect(Op._tag).toBe("OpFactory");
     });
     test('callable Op has type discriminant Typed<"Op">', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,19 +2,20 @@ import { assert, describe, expect, expectTypeOf, test, vi } from "vitest";
 import {
   Op,
   TimeoutError,
-  UnexpectedError,
-  TypedError,
+  UnhandledException,
+  TaggedError,
   ErrorGroup,
   exponentialBackoff,
   type Op as OpT,
 } from "./index.js";
 import type { RetryPolicy } from "./policies.js";
 import type { Result } from "./result.js";
+import type { TaggedErrorInstance } from "better-result";
 
 describe("public API (index)", () => {
   describe("OpFactory", () => {
     test("type is 'OpFactory'", () => {
-      expect(Op.type).toBe("OpFactory");
+      expect(Op._tag).toBe("OpFactory");
     });
     test("run is a function", () => {
       expect(Op.run).toBeInstanceOf(Function);
@@ -32,22 +33,22 @@ describe("public API (index)", () => {
       expect(getDelay(5)).toBe(1000); // clamped by maxMs
     });
   });
-  describe("UnexpectedError", () => {
+  describe("UnhandledException", () => {
     test("discriminant and cause", () => {
       const cause = new Error("root");
-      const e = new UnexpectedError(cause);
-      expect(e.type).toBe("UnexpectedError");
-      expect(e.message).toBe("An unexpected error occurred");
+      const e = new UnhandledException({ cause });
+      expect(e._tag).toBe("UnhandledException");
+      expect(e.message).toBe("Unhandled exception: root");
       expect(e.cause).toBe(cause);
     });
   });
 
-  describe("TypedError", () => {
+  describe("TaggedError", () => {
     test("factory produces typed errors", () => {
-      class SmokeError extends TypedError("SmokeError", "default smoke") {}
+      const SmokeError = TaggedError("SmokeError")<{ message: string }>();
       const e = new SmokeError({ message: "x" });
-      expectTypeOf(e).toEqualTypeOf<TypedError<"SmokeError", {}>>();
-      expect(e.type).toBe("SmokeError");
+      expectTypeOf(e).toEqualTypeOf<TaggedErrorInstance<"SmokeError", { message: string }>>();
+      expect(e._tag).toBe("SmokeError");
       expect(e.name).toBe("SmokeError");
       expect(e.message).toBe("x");
     });
@@ -56,11 +57,11 @@ describe("public API (index)", () => {
   describe("Op.of / Op.fail", () => {
     test("pure does not yield errors; fail does not", async () => {
       const okR = await Op.of(7).run();
-      assert(okR.ok === true, "okR.ok");
+      assert(okR.isOk() === true, "should be Ok");
       expect(okR.value).toBe(7);
 
       const errR = await Op.fail("no").run();
-      assert(errR.ok === false, "errR.ok");
+      assert(errR.isErr() === true, "should be Err");
       expect(errR.error).toBe("no");
     });
   });
@@ -71,25 +72,25 @@ describe("public API (index)", () => {
         () => Promise.resolve(3),
         () => "mapped",
       ).run();
-      assert(okR.ok === true, "okR.ok");
+      assert(okR.isOk() === true, "should be Ok");
       expect(okR.value).toBe(3);
 
       const errR = await Op.try(
         () => (Math.random() > 1 ? Promise.resolve(3) : Promise.reject("boom")),
         (e) => ({ mappedError: String(e) }),
       ).run();
-      assert(errR.ok === false, "errR.ok should be false");
+      assert(errR.isErr() === true, "should be Err");
       expect(errR.error).toEqual({ mappedError: "boom" });
     });
 
     test("works synchronously", async () => {
-      // default maps to UnexpectedError
+      // default maps to UnhandledException
       {
         const result = await Op.try(async () => {
           await Promise.reject("failed");
         }).run();
-        assert(result.ok === false, "result.ok should be false");
-        expect(result.error).toBeInstanceOf(UnexpectedError);
+        assert(result.isErr() === true, "should be Err");
+        expect(result.error).toBeInstanceOf(UnhandledException);
         expect(result.error.cause).toBe("failed");
       }
       // explicitly mapped
@@ -100,17 +101,17 @@ describe("public API (index)", () => {
           },
           (e) => ({ mappedError: String(e) }),
         ).run();
-        assert(result.ok === false, "result.ok should be false");
+        assert(result.isErr() === true, "should be Err");
         expect(result.error).toEqual({ mappedError: "69" });
       }
-      // sync throw defaults maps to UnexpectedError
+      // sync throw defaults maps to UnhandledException
       {
         const syncThrow = new Error("failed");
         const result = await Op.try(async () => {
           throw syncThrow;
         }).run();
-        assert(result.ok === false, "result.ok should be false");
-        expect(result.error).toBeInstanceOf(UnexpectedError);
+        assert(result.isErr() === true, "should be Err");
+        expect(result.error).toBeInstanceOf(UnhandledException);
         expect(result.error.cause).toBe(syncThrow);
       }
       // explicitly mapped
@@ -121,7 +122,7 @@ describe("public API (index)", () => {
           },
           (e) => ({ mappedError: String(e) }),
         ).run();
-        assert(result.ok === false, "result.ok should be false");
+        assert(result.isErr() === true, "should be Err");
         expect(result.error).toEqual({ mappedError: "69" });
       }
       // success path
@@ -129,7 +130,7 @@ describe("public API (index)", () => {
         const result = await Op.try(async () => {
           return 69;
         }).run();
-        assert(result.ok === true, "result.ok should be true");
+        assert(result.isOk() === true, "result should be Ok");
         expect(result.value).toBe(69);
       }
     });
@@ -160,7 +161,7 @@ describe("public API (index)", () => {
       });
 
       const result = await program.run();
-      assert(result.ok === true, "result.ok should be true");
+      assert(result.isOk() === true, "result should be Ok");
       expect(result.value).toBe(69);
       expect(attempts).toBe(2);
     });
@@ -176,7 +177,7 @@ describe("public API (index)", () => {
         return id.length;
       }).withRetry(immediateRetry(transient));
       const asyncResult = await asyncProgram.run("abcd");
-      assert(asyncResult.ok === true, "asyncResult.ok should be true");
+      assert(asyncResult.isOk() === true, "should be Ok");
       expect(asyncResult.value).toBe(4);
       expect(asyncAttempts).toBe(2);
 
@@ -189,7 +190,7 @@ describe("public API (index)", () => {
         return id.toUpperCase();
       }).withRetry(immediateRetry("retry me"));
       const genResult = await generatorProgram.run("ok");
-      assert(genResult.ok === true, "genResult.ok should be true");
+      assert(genResult.isOk() === true, "should be Ok");
       expect(genResult.value).toBe("OK");
       expect(genAttempts).toBe(2);
     });
@@ -210,7 +211,7 @@ describe("public API (index)", () => {
         await vi.advanceTimersByTimeAsync(100);
         const result = await runPromise;
 
-        assert(result.ok === false, "result.ok should be false");
+        assert(result.isErr() === true, "should be Err");
         expect(result.error).toBeInstanceOf(TimeoutError);
       } finally {
         vi.useRealTimers();
@@ -239,7 +240,7 @@ describe("public API (index)", () => {
         const runPromise = program.run();
         await vi.advanceTimersByTimeAsync(150);
         const result = await runPromise;
-        assert(result.ok === true, "result.ok should be true");
+        assert(result.isOk() === true, "result should be Ok");
         expect(result.value).toBe(69);
         expect(attempts).toBe(2);
       } finally {
@@ -269,14 +270,16 @@ describe("public API (index)", () => {
           (cause) => String(cause instanceof Error ? cause.message : cause),
         ).withSignal(controller.signal);
 
-        expectTypeOf(op.run()).toEqualTypeOf<Promise<Result<number, string | UnexpectedError>>>();
+        expectTypeOf(op.run()).toEqualTypeOf<
+          Promise<Result<number, string | UnhandledException>>
+        >();
 
         const runPromise = op.run();
         controller.abort(new Error("cancelled"));
         await vi.advanceTimersByTimeAsync(0);
 
         const result = await runPromise;
-        assert(result.ok === false, "result.ok should be false");
+        assert(result.isErr() === true, "should be Err");
         expect(result.error).toBe("cancelled");
       } finally {
         vi.useRealTimers();
@@ -293,7 +296,7 @@ describe("public API (index)", () => {
           return a + b;
         });
         const r = await program.run();
-        assert(r.ok === true, "r.ok");
+        assert(r.isOk() === true, "should be Ok");
         expect(r.value).toBe(12);
       }
       {
@@ -303,7 +306,7 @@ describe("public API (index)", () => {
           return a + b;
         });
         const r = await program.run();
-        assert(r.ok === true, "r.ok");
+        assert(r.isOk() === true, "should be Ok");
         expect(r.value).toBe(30);
       }
       {
@@ -313,9 +316,9 @@ describe("public API (index)", () => {
           return a + b;
         });
         const r = await program.run();
-        assert(r.ok === false, "r.ok");
-        expect(r.error).toBeInstanceOf(UnexpectedError);
-        expectTypeOf(r.error).toEqualTypeOf<UnexpectedError>();
+        assert(r.isErr() === true, "should be Err");
+        expect(r.error).toBeInstanceOf(UnhandledException);
+        expectTypeOf(r.error).toEqualTypeOf<UnhandledException>();
         expect(r.error.cause).toBe("boom");
       }
       {
@@ -328,9 +331,9 @@ describe("public API (index)", () => {
           );
         });
         const r = await program.run();
-        assert(r.ok === false, "r.ok");
-        expect(r.error).toBeInstanceOf(UnexpectedError);
-        expectTypeOf(r.error).toEqualTypeOf<UnexpectedError>();
+        assert(r.isErr() === true, "should be Err");
+        expect(r.error).toBeInstanceOf(UnhandledException);
+        expectTypeOf(r.error).toEqualTypeOf<UnhandledException>();
         expect(r.error.cause).toBe(error);
       }
     });
@@ -343,9 +346,9 @@ describe("public API (index)", () => {
           return a + b + c;
         });
         const r = await program.run();
-        assert(r.ok === false, "r.ok");
+        assert(r.isErr() === true, "should be Err");
         expect(r.error).toBe("boom");
-        expectTypeOf(r.error).toEqualTypeOf<UnexpectedError | string>();
+        expectTypeOf(r.error).toEqualTypeOf<UnhandledException | string>();
       }
     });
   });
@@ -353,27 +356,27 @@ describe("public API (index)", () => {
   describe("Op.run", () => {
     test("free-function run executes nullary ops", async () => {
       const r1 = await Op.run(Op.of(69));
-      assert(r1.ok === true, "r1.ok");
+      assert(r1.isOk() === true, "should be Ok");
       expect(r1.value).toBe(69);
 
       const nullary = Op(function* () {
         return 1;
       });
       const r2 = await Op.run(nullary);
-      assert(r2.ok === true, "r2.ok");
+      assert(r2.isOk() === true, "should be Ok");
       expect(r2.value).toBe(1);
     });
   });
 
   describe("Op namespace value", () => {
     test("Op.type is 'OpFactory'", () => {
-      expect(Op.type).toBe("OpFactory");
+      expect(Op._tag).toBe("OpFactory");
     });
     test('callable Op has type discriminant Typed<"Op">', () => {
       const p = Op(function* () {
         return yield* Op.of(1);
       });
-      expect(p.type).toBe("Op");
+      expect(p._tag).toBe("Op");
     });
   });
 });
@@ -387,7 +390,17 @@ function bind<A, E1, B, E2>(m: OpT<A, E1, []>, f: (a: A) => OpT<B, E2, []>): OpT
 }
 
 async function expectSameResult<T, E>(a: Op<T, E, []>, b: Op<T, E, []>) {
-  expect(await Op.run(a)).toEqual(await Op.run(b));
+  const left = await Op.run(a);
+  const right = await Op.run(b);
+
+  expect(left.isOk()).toBe(right.isOk());
+  if (left.isOk() && right.isOk()) {
+    expect(left.value).toEqual(right.value);
+    return;
+  }
+  if (left.isErr() && right.isErr()) {
+    expect(left.error).toEqual(right.error);
+  }
 }
 
 describe("Op monad laws (via bind / run)", () => {
@@ -467,7 +480,7 @@ const invalidConcurrencies = [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY];
 describe("Op.all", () => {
   test("tuple of successes in input order", async () => {
     const r = await Op.all([Op.of(1), Op.of("two"), Op.of(true)]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toEqual([1, "two", true]);
     const [n, s, b] = r.value;
     expectTypeOf(n).toEqualTypeOf<number>();
@@ -477,7 +490,7 @@ describe("Op.all", () => {
 
   test("empty input succeeds with []", async () => {
     const r = await Op.all([]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toEqual([]);
   });
 
@@ -503,28 +516,28 @@ describe("Op.all", () => {
     const fast = Op.fail("boom" as const);
 
     const r = await Op.all([slow, fast]).run();
-    assert(r.ok === false, "err");
+    assert(r.isErr() === true, "should be Err");
     expect(r.error).toBe("boom");
     expect(siblingAborted).toBe(true);
   });
 
   test("union error type across children", async () => {
-    class AErr extends TypedError("AErr") {}
-    class BErr extends TypedError("BErr") {}
+    class AErr extends TaggedError("AErr")() {}
+    class BErr extends TaggedError("BErr")() {}
     const n: number = 1;
     const s: string = "x";
     const a = Op(function* () {
-      if (Math.random() > 2) return yield* new AErr();
+      if (Math.random() > 2) return yield* Op.fail(new AErr());
       return n;
     });
     const b = Op(function* () {
-      if (Math.random() > 2) return yield* new BErr();
+      if (Math.random() > 2) return yield* Op.fail(new BErr());
       return s;
     });
     const combined = Op.all([a, b]);
     const r = await combined.run();
-    if (!r.ok) {
-      expectTypeOf(r.error).toEqualTypeOf<AErr | BErr | UnexpectedError>();
+    if (r.isErr()) {
+      expectTypeOf(r.error).toEqualTypeOf<AErr | BErr | UnhandledException>();
     }
   });
 
@@ -586,7 +599,7 @@ describe("Op.all", () => {
     fourthGate.resolve(3);
     const r = await run;
 
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toEqual([0, 1, 2, 3]);
     expect(maxActive).toBeLessThanOrEqual(2);
   });
@@ -611,7 +624,7 @@ describe("Op.all", () => {
 
     const r = await Op.all([slow, fast, queued], 2).run();
 
-    assert(r.ok === false, "err");
+    assert(r.isErr() === true, "should be Err");
     expect(r.error).toBe("boom");
     expect(slowObservedAbort).toBe(true);
     expect(queuedStarted).toBe(false);
@@ -621,9 +634,9 @@ describe("Op.all", () => {
 describe("Op.allSettled", () => {
   test("returns tuple of Result in input order", async () => {
     const r = await Op.allSettled([Op.of(1), Op.fail("no" as const), Op.of("ok")]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     const [a, b, c] = r.value;
-    assert(a.ok === true && b.ok === false && c.ok === true, "branches");
+    assert(a.isOk() && b.isErr() && c.isOk(), "branches");
     expect(a.value).toBe(1);
     expect(b.error).toBe("no");
     expect(c.value).toBe("ok");
@@ -631,7 +644,7 @@ describe("Op.allSettled", () => {
 
   test("empty input succeeds with []", async () => {
     const r = await Op.allSettled([]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toEqual([]);
   });
 
@@ -644,12 +657,12 @@ describe("Op.allSettled", () => {
   test("never fails", async () => {
     const combined = Op.allSettled([Op.fail(1), Op.fail("two" as const)]);
     const r = await combined.run();
-    // Even a `never`-failing op still widens to UnexpectedError after .run() since the
+    // Even a `never`-failing op still widens to UnhandledException after .run() since the
     // runtime can always throw in user code. What matters: .ok is always true here.
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     const [a, b] = r.value;
-    expectTypeOf(a).toEqualTypeOf<Result<never, number | UnexpectedError>>();
-    expectTypeOf(b).toEqualTypeOf<Result<never, "two" | UnexpectedError>>();
+    expectTypeOf(a).toEqualTypeOf<Result<never, number | UnhandledException>>();
+    expectTypeOf(b).toEqualTypeOf<Result<never, "two" | UnhandledException>>();
   });
 
   test("does not abort siblings on failure", async () => {
@@ -666,10 +679,10 @@ describe("Op.allSettled", () => {
         }),
     );
     const r = await Op.allSettled([slow, Op.fail("boom")]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(siblingAborted).toBe(false);
     const [first] = r.value;
-    assert(first.ok === true, "slow sibling completed normally");
+    assert(first.isOk() === true, "slow sibling completed normally");
     expect(first.value).toBe(1);
   });
 
@@ -686,10 +699,10 @@ describe("Op.allSettled", () => {
 
     const r = await Op.allSettled([first, second], 1).run();
 
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(started).toEqual([0, 1]);
     const [a, b] = r.value;
-    assert(a.ok === false && b.ok === true, "branches");
+    assert(a.isErr() && b.isOk(), "branches");
     expect(a.error).toBe("boom");
     expect(b.value).toBe("ok");
   });
@@ -698,25 +711,25 @@ describe("Op.allSettled", () => {
 describe("Op.settle", () => {
   test("wraps success in a settled Result", async () => {
     const r = await Op.settle(Op.of(42)).run();
-    assert(r.ok === true, "outer op is always ok");
+    assert(r.isOk() === true, "should be Ok");
     const settled = r.value;
-    assert(settled.ok === true, "inner op succeeded");
+    assert(settled.isOk() === true, "inner op succeeded");
     expect(settled.value).toBe(42);
   });
 
   test("wraps failure in a settled Result", async () => {
     const r = await Op.settle(Op.fail("nope" as const)).run();
-    assert(r.ok === true, "outer op is always ok");
+    assert(r.isOk() === true, "should be Ok");
     const settled = r.value;
-    assert(settled.ok === false, "inner op failed");
+    assert(settled.isErr() === true, "inner op failed");
     expect(settled.error).toBe("nope");
   });
 
   test("preserves child result typing", async () => {
     const combined = Op.settle(Op.fail(1));
     const r = await combined.run();
-    assert(r.ok === true, "outer op is always ok");
-    expectTypeOf(r.value).toEqualTypeOf<Result<never, number | UnexpectedError>>();
+    assert(r.isOk() === true, "should be Ok");
+    expectTypeOf(r.value).toEqualTypeOf<Result<never, number | UnhandledException>>();
   });
 });
 
@@ -735,7 +748,7 @@ describe("Op.any", () => {
         }),
     );
     const r = await Op.any([slow, Op.of(69)]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toBe(69);
     expect(slowAborted).toBe(true);
   });
@@ -746,14 +759,14 @@ describe("Op.any", () => {
       Op.fail("b" as const),
       Op.fail("c" as const),
     ]).run();
-    assert(r.ok === false, "err");
+    assert(r.isErr() === true, "should be Err");
     assert(r.error instanceof ErrorGroup, "ErrorGroup");
     expect(r.error.errors).toEqual(["a", "b", "c"]);
   });
 
   test("empty input fails with empty ErrorGroup", async () => {
     const r = await Op.any([]).run();
-    assert(r.ok === false, "err");
+    assert(r.isErr() === true, "should be Err");
     assert(r.error instanceof ErrorGroup, "ErrorGroup");
     expect(r.error.errors).toEqual([]);
   });
@@ -761,8 +774,8 @@ describe("Op.any", () => {
   test("error type is ErrorGroup<union of child errors>", async () => {
     const combined = Op.any([Op.fail(1), Op.fail("two" as const)]);
     const r = await combined.run();
-    if (!r.ok && r.error instanceof ErrorGroup) {
-      expectTypeOf(r.error.errors).toEqualTypeOf<(number | "two" | UnexpectedError)[]>();
+    if (r.isErr() && r.error instanceof ErrorGroup) {
+      expectTypeOf(r.error.errors).toEqualTypeOf<(number | "two" | UnhandledException)[]>();
     }
   });
 
@@ -775,7 +788,7 @@ describe("Op.any", () => {
       Op.try(() => rejectAfter("slow", 10), toTag("slow")),
       Op.try(() => rejectAfter("fast", 0), toTag("fast")),
     ]).run();
-    assert(r.ok === false, "err");
+    assert(r.isErr() === true, "should be Err");
     assert(r.error instanceof ErrorGroup, "ErrorGroup");
     expect(r.error.errors).toEqual(["slow", "fast"]);
   });
@@ -797,7 +810,7 @@ describe("Op.race", () => {
     );
     const fast = Op.try(() => resolveAfter(7, 0));
     const r = await Op.race([slow, fast]).run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toBe(7);
     expect(loserAborted).toBe(true);
   });
@@ -806,7 +819,7 @@ describe("Op.race", () => {
     const slow = Op.try(() => resolveAfter(1, 20));
     const fast = Op.fail("quick" as const);
     const r = await Op.race([slow, fast]).run();
-    assert(r.ok === false, "err");
+    assert(r.isErr() === true, "should be Err");
     expect(r.error).toBe("quick");
   });
 
@@ -830,8 +843,8 @@ describe("Op.race", () => {
   test("union type across children", async () => {
     const combined = Op.race([Op.of(1), Op.fail("two" as const)]);
     const r = await combined.run();
-    if (r.ok) expectTypeOf(r.value).toEqualTypeOf<number>();
-    if (!r.ok) expectTypeOf(r.error).toEqualTypeOf<"two" | UnexpectedError>();
+    if (r.isOk()) expectTypeOf(r.value).toEqualTypeOf<number>();
+    if (r.isErr()) expectTypeOf(r.error).toEqualTypeOf<"two" | UnhandledException>();
   });
 });
 
@@ -843,7 +856,7 @@ describe("Op combinators compose with withTimeout / withRetry", () => {
       const promise = Op.all([slow, slow]).withTimeout(10).run();
       await vi.advanceTimersByTimeAsync(15);
       const r = await promise;
-      assert(r.ok === false, "err");
+      assert(r.isErr() === true, "should be Err");
       expect(r.error).toBeInstanceOf(TimeoutError);
     } finally {
       vi.useRealTimers();
@@ -860,7 +873,7 @@ describe("Op combinators compose with withTimeout / withRetry", () => {
     const r = await Op.any([flaky])
       .withRetry({ maxAttempts: 3, shouldRetry: () => true, getDelay: () => 0 })
       .run();
-    assert(r.ok === true, "ok");
+    assert(r.isOk() === true, "should be Ok");
     expect(r.value).toBe(11);
     expect(attempts).toBe(2);
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -527,11 +527,11 @@ describe("Op.all", () => {
     const n: number = 1;
     const s: string = "x";
     const a = Op(function* () {
-      if (Math.random() > 2) return yield* Op.fail(new AErr());
+      if (Math.random() > 2) return yield* new AErr();
       return n;
     });
     const b = Op(function* () {
-      if (Math.random() > 2) return yield* Op.fail(new BErr());
+      if (Math.random() > 2) return yield* new BErr();
       return s;
     });
     const combined = Op.all([a, b]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,9 @@ import { succeed, fail, _try, fromGenFn } from "./builders.js";
 import { allOp, allSettledOp, anyOp, raceOp, settleOp } from "./combinators.js";
 import { runOp, type Op as _Op } from "./core.js";
 import { exponentialBackoff } from "./policies.js";
-import {
-  ErrorGroup,
-  TimeoutError,
-  UnhandledException,
-  UnreachableError,
-  TaggedError,
-} from "./errors.js";
+import { ErrorGroup, TimeoutError, UnreachableError } from "./errors.js";
+
+export * from "better-result";
 
 export const Op = Object.assign(fromGenFn, {
   _tag: "OpFactory" as const,
@@ -39,11 +35,4 @@ export const Op = Object.assign(fromGenFn, {
  */
 export type Op<T, E, A extends readonly unknown[]> = _Op<T, E, A>;
 
-export {
-  TaggedError,
-  TimeoutError,
-  UnhandledException,
-  UnreachableError,
-  ErrorGroup,
-  exponentialBackoff,
-};
+export { TimeoutError, UnreachableError, ErrorGroup, exponentialBackoff };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,13 @@ import { exponentialBackoff } from "./policies.js";
 import {
   ErrorGroup,
   TimeoutError,
-  UnexpectedError,
+  UnhandledException,
   UnreachableError,
-  TypedError,
+  TaggedError,
 } from "./errors.js";
 
 export const Op = Object.assign(fromGenFn, {
-  type: "OpFactory" as const,
+  _tag: "OpFactory" as const,
   run: runOp,
   of: succeed,
   fail,
@@ -34,15 +34,15 @@ export const Op = Object.assign(fromGenFn, {
  * `withRetry(policy)`, `withTimeout(ms)`, and `withSignal(signal)`.
  *
  * @template T Value returned when the operation succeeds.
- * @template E Error type from yielded failures (not counting {@link UnexpectedError} from throws).
+ * @template E Error type from yielded failures (not counting {@link UnhandledException} from throws).
  * @template A Argument tuple for parameterized operations.
  */
 export type Op<T, E, A extends readonly unknown[]> = _Op<T, E, A>;
 
 export {
-  TypedError,
+  TaggedError,
   TimeoutError,
-  UnexpectedError,
+  UnhandledException,
   UnreachableError,
   ErrorGroup,
   exponentialBackoff,

--- a/src/policies.test.ts
+++ b/src/policies.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, assert, expectTypeOf, vi } from "vitest";
 import { fail, fromGenFn, succeed, _try } from "./builders.js";
 import type { Op } from "./core.js";
 import type { Result } from "./result.js";
-import { TimeoutError, UnexpectedError, TypedError } from "./errors.js";
+import { TimeoutError, UnhandledException, TaggedError } from "./errors.js";
 import type { RetryPolicy } from "./policies.js";
 
 describe("withRetry", () => {
@@ -40,7 +40,7 @@ describe("withRetry", () => {
     const program = createFetchProgram(fetcher);
 
     const result = await program.run("123");
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result.ok should be true");
     expect(result.value).toEqual({ url: `https://example.com/123` });
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
@@ -55,7 +55,7 @@ describe("withRetry", () => {
     const program = createFetchProgram(fetcher, policy);
 
     const result = await program.run("123");
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toEqual({ url: `https://example.com/123` });
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
@@ -67,8 +67,8 @@ describe("withRetry", () => {
     const program = createFetchProgram(fetcher, retryFetchError);
 
     const result = await program.run("123");
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "result should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(fetcher).toHaveBeenCalledTimes(3);
   });
 
@@ -86,8 +86,8 @@ describe("withRetry", () => {
     const program = createFetchProgram(fetcher, policy);
 
     const result = await program.run("123");
-    assert(result.ok === false, "result.ok should be false");
-    expect(result.error).toBeInstanceOf(UnexpectedError);
+    assert(result.isErr() === true, "result should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
@@ -111,7 +111,7 @@ describe("withRetry", () => {
       await vi.advanceTimersByTimeAsync(1);
 
       const result = await runPromise;
-      assert(result.ok === true, "result.ok should be true");
+      assert(result.isOk() === true, "result should be Ok");
       expect(fetcher).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
@@ -133,12 +133,12 @@ describe("withRetry", () => {
     });
 
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toEqual({ ok: true });
     expect(attempts).toBe(2);
   });
 
-  test("wrapping _try directly can retry UnexpectedError causes", async () => {
+  test("wrapping _try directly can retry UnhandledException causes", async () => {
     let attempts = 0;
     const transient = new Error("temporary outage");
     const program = _try(async () => {
@@ -154,7 +154,7 @@ describe("withRetry", () => {
     });
 
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe("done");
     expect(attempts).toBe(3);
   });
@@ -182,7 +182,7 @@ describe("withRetry", () => {
     });
 
     const result = await parent.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(69);
     expect(attempts).toBe(2);
   });
@@ -203,7 +203,7 @@ describe("withRetry", () => {
     });
 
     const result = await program.run("123");
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toEqual({ url: "https://example.com/123" });
     expect(attempts).toBe(2);
   });
@@ -223,7 +223,7 @@ describe("withRetry", () => {
     });
 
     const result = await program.run("123");
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toEqual({ url: "https://example.com/123" });
     expect(attempts).toBe(2);
   });
@@ -233,7 +233,7 @@ describe("withTimeout", () => {
   test("succeeds when the operation completes before timeout", async () => {
     const program = _try(() => Promise.resolve(69)).withTimeout(100);
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(69);
   });
 
@@ -250,7 +250,7 @@ describe("withTimeout", () => {
       await vi.advanceTimersByTimeAsync(100);
 
       const result = await runPromise;
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "result should be Err");
       expect(result.error).toBeInstanceOf(TimeoutError);
       if (result.error instanceof TimeoutError) {
         expect(result.error.timeoutMs).toBe(100);
@@ -289,7 +289,7 @@ describe("withTimeout", () => {
       await vi.advanceTimersByTimeAsync(100);
 
       const result = await runPromise;
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "result should be Err");
       expect(result.error).toBeInstanceOf(TimeoutError);
       expect(attempts).toBe(2);
     } finally {
@@ -320,7 +320,7 @@ describe("withTimeout", () => {
       await vi.advanceTimersByTimeAsync(150);
 
       const result = await runPromise;
-      assert(result.ok === true, "result.ok should be true");
+      assert(result.isOk() === true, "result should be Ok");
       expect(result.value).toBe(69);
       expect(attempts).toBe(2);
     } finally {
@@ -330,7 +330,7 @@ describe("withTimeout", () => {
 
   test("withTimeout preserves inferred op shapes", async () => {
     const p1 = _try(() => Promise.resolve(1)).withTimeout(10);
-    expectTypeOf(p1).toEqualTypeOf<Op<number, UnexpectedError | TimeoutError, []>>();
+    expectTypeOf(p1).toEqualTypeOf<Op<number, UnhandledException | TimeoutError, []>>();
 
     const p2 = _try(
       () => Promise.resolve(1),
@@ -344,17 +344,17 @@ describe("withTimeout", () => {
     expectTypeOf(p3).toEqualTypeOf<Op<number, TimeoutError, [id: string]>>();
 
     const r1 = p1.run();
-    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, TimeoutError | UnexpectedError>>>();
+    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, TimeoutError | UnhandledException>>>();
 
     const r2 = p2.run();
     expectTypeOf(r2).toEqualTypeOf<
-      Promise<Result<number, string | TimeoutError | UnexpectedError>>
+      Promise<Result<number, string | TimeoutError | UnhandledException>>
     >();
 
     const r3 = p3.run("abc");
-    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, TimeoutError | UnexpectedError>>>();
+    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, TimeoutError | UnhandledException>>>();
 
-    expect((await p1.run()).ok).toBe(true);
+    expect((await p1.run()).isOk()).toBe(true);
 
     // @ts-expect-error - nullary timeout op does not accept args
     p1.run(1);
@@ -364,7 +364,7 @@ describe("withTimeout", () => {
     p3.run("abc", "extra");
 
     let attempts = 0;
-    class FetchError extends TypedError("FetchError") {}
+    class FetchError extends TaggedError("FetchError")() {}
     const fetcher = async () => {
       attempts++;
       if (attempts === 1) {
@@ -386,9 +386,9 @@ describe("withTimeout", () => {
     expectTypeOf(p4).toEqualTypeOf<Op<number, TimeoutError | FetchError, []>>();
     const result = await p4.run();
     expectTypeOf(result).toEqualTypeOf<
-      Result<number, TimeoutError | FetchError | UnexpectedError>
+      Result<number, TimeoutError | FetchError | UnhandledException>
     >();
-    assert(result.ok === false, "result.ok should be false");
+    assert(result.isErr() === true, "result should be Err");
     expect(result.error).toBeInstanceOf(TimeoutError);
   });
 });
@@ -403,7 +403,7 @@ describe("withSignal", () => {
     }).withSignal(controller.signal);
 
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(result.value).toBe(69);
     expect(seenSignal).toBeInstanceOf(AbortSignal);
     expect(seenSignal?.aborted).toBe(false);
@@ -434,7 +434,7 @@ describe("withSignal", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       const result = await runPromise;
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "result should be Err");
       expect(result.error).toBe("request cancelled");
     } finally {
       vi.useRealTimers();
@@ -444,7 +444,7 @@ describe("withSignal", () => {
   test("withSignal preserves inferred op shapes", async () => {
     const controller = new AbortController();
     const p1 = _try(() => Promise.resolve(1)).withSignal(controller.signal);
-    expectTypeOf(p1).toEqualTypeOf<Op<number, UnexpectedError, []>>();
+    expectTypeOf(p1).toEqualTypeOf<Op<number, UnhandledException, []>>();
 
     const p2 = _try(
       () => Promise.resolve(1),
@@ -458,15 +458,15 @@ describe("withSignal", () => {
     expectTypeOf(p3).toEqualTypeOf<Op<number, never, [id: string]>>();
 
     const r1 = p1.run();
-    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, UnexpectedError>>>();
+    expectTypeOf(r1).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
 
     const r2 = p2.run();
-    expectTypeOf(r2).toEqualTypeOf<Promise<Result<number, string | UnexpectedError>>>();
+    expectTypeOf(r2).toEqualTypeOf<Promise<Result<number, string | UnhandledException>>>();
 
     const r3 = p3.run("abc");
-    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, UnexpectedError>>>();
+    expectTypeOf(r3).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
 
-    expect((await p1.run()).ok).toBe(true);
+    expect((await p1.run()).isOk()).toBe(true);
 
     // @ts-expect-error - nullary withSignal op does not accept args
     p1.run(1);
@@ -485,7 +485,7 @@ describe("AbortSignal", () => {
       return Promise.resolve("ok");
     });
     const result = await program.run();
-    assert(result.ok === true, "result.ok should be true");
+    assert(result.isOk() === true, "result should be Ok");
     expect(seen).toBeInstanceOf(AbortSignal);
     expect(seen?.aborted).toBe(false);
   });
@@ -510,7 +510,7 @@ describe("AbortSignal", () => {
       await vi.advanceTimersByTimeAsync(100);
       const result = await runPromise;
 
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "result should be Err");
       expect(result.error).toBeInstanceOf(TimeoutError);
       expect(seenSignal?.aborted).toBe(true);
       expect(seenSignal?.reason).toBeInstanceOf(TimeoutError);
@@ -548,7 +548,7 @@ describe("AbortSignal", () => {
       await vi.advanceTimersByTimeAsync(200);
 
       const result = await runPromise;
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "result should be Err");
       expect(result.error).toBeInstanceOf(TimeoutError);
       expect(aborted).toBe(true);
       expect(attempts).toBeGreaterThanOrEqual(1);
@@ -577,7 +577,7 @@ describe("AbortSignal", () => {
       await vi.advanceTimersByTimeAsync(200);
 
       const result = await runPromise;
-      assert(result.ok === false, "result.ok should be false");
+      assert(result.isErr() === true, "result should be Err");
       expect(result.error).toBeInstanceOf(TimeoutError);
       // Only one attempt ran before the timeout aborted the delay and halted the loop.
       expect(attempts).toBe(1);

--- a/src/policies.test.ts
+++ b/src/policies.test.ts
@@ -7,7 +7,7 @@ import type { RetryPolicy } from "./policies.js";
 
 describe("withRetry", () => {
   class FetchError extends Error {
-    readonly type = "FetchError";
+    readonly _tag = "FetchError";
   }
 
   const createFetcher = (maxRetries = 1) => {

--- a/src/policies.ts
+++ b/src/policies.ts
@@ -1,4 +1,4 @@
-import { TimeoutError, UnexpectedError, UnreachableError } from "./errors.js";
+import { TimeoutError, UnreachableError, UnhandledException } from "./errors.js";
 import { err, type Result } from "./result.js";
 import { drive, makeNullaryOp, type Op, type OpArity, type Instruction } from "./core.js";
 
@@ -48,7 +48,7 @@ const mapFluentOp = <T, EIn, EOut, A extends readonly unknown[]>(
     withRetry: (policy?: RetryPolicy) => withRetryOp(out as never, policy),
     withTimeout: (timeoutMs: number) => withTimeoutOp(out as never, timeoutMs),
     withSignal: (signal: AbortSignal) => withSignalOp(out as never, signal),
-    type: "Op" as const,
+    _tag: "Op" as const,
   });
 
   return out as never;
@@ -70,23 +70,23 @@ const withRetryNullaryOp = <T, E>(
   op: Op<T, E, readonly []>,
   policy: RetryPolicy = DEFAULT_RETRY_POLICY,
 ): Op<T, E, readonly []> => {
-  return makePolicyNullaryOp<T, E | UnexpectedError>(function* () {
+  return makePolicyNullaryOp<T, E | UnhandledException>(function* () {
     let attempt = 1;
 
     while (true) {
       const attemptStep = (yield {
-        type: "Suspended",
+        _tag: "Suspended",
         suspend: (signal: AbortSignal) =>
           drive(op, signal).then((result) => ({ result, aborted: signal.aborted })),
-      }) as { result: Result<T, E | UnexpectedError>; aborted: boolean };
+      }) as { result: Result<T, E | UnhandledException>; aborted: boolean };
 
       const result = attemptStep.result;
-      if (result.ok) {
+      if (result.isOk()) {
         return result.value;
       }
 
       const cause = result.error;
-      const retryCause = cause instanceof UnexpectedError ? cause.cause : cause;
+      const retryCause = cause instanceof UnhandledException ? cause.cause : cause;
       const canRetry =
         !attemptStep.aborted && attempt < policy.maxAttempts && policy.shouldRetry(retryCause);
       if (!canRetry) {
@@ -97,7 +97,7 @@ const withRetryNullaryOp = <T, E>(
       const delayMs = Math.max(0, policy.getDelay(attempt));
       if (delayMs > 0) {
         const delayAborted = (yield {
-          type: "Suspended",
+          _tag: "Suspended",
           suspend: (signal: AbortSignal) =>
             abortableDelay(delayMs, signal).then(() => signal.aborted),
         }) as boolean;
@@ -117,13 +117,13 @@ const withTimeoutNullaryOp = <T, E>(
   timeoutMs: number,
 ): Op<T, E | TimeoutError, readonly []> => {
   const clampedTimeoutMs = Math.max(0, timeoutMs);
-  return makePolicyNullaryOp<T, E | UnexpectedError | TimeoutError>(function* () {
+  return makePolicyNullaryOp<T, E | UnhandledException | TimeoutError>(function* () {
     const result = (yield {
-      type: "Suspended",
+      _tag: "Suspended",
       suspend: (outerSignal: AbortSignal) =>
         raceTimeout((signal) => drive(op, signal), clampedTimeoutMs, outerSignal),
-    }) as Result<T, E | UnexpectedError | TimeoutError>;
-    if (!result.ok) {
+    }) as Result<T, E | UnhandledException | TimeoutError>;
+    if (result.isErr()) {
       yield err(result.error);
       throw new UnreachableError();
     }
@@ -135,13 +135,13 @@ const withSignalNullaryOp = <T, E>(
   op: Op<T, E, readonly []>,
   signal: AbortSignal,
 ): Op<T, E, readonly []> => {
-  return makePolicyNullaryOp<T, E | UnexpectedError>(function* () {
+  return makePolicyNullaryOp<T, E | UnhandledException>(function* () {
     const result = (yield {
-      type: "Suspended" as const,
+      _tag: "Suspended" as const,
       suspend: (outerSignal: AbortSignal) =>
         runWithBoundSignal((mergedSignal) => drive(op, mergedSignal), signal, outerSignal),
-    }) as Result<T, E | UnexpectedError>;
-    if (!result.ok) {
+    }) as Result<T, E | UnhandledException>;
+    if (result.isErr()) {
       yield err(result.error);
       throw new UnreachableError();
     }

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,23 +1,9 @@
-import type { Typed } from "./typed.js";
+import { Result, type Err, type Ok } from "better-result";
 
-export interface Ok<T> extends Typed<"Ok"> {
-  readonly ok: true;
-  readonly value: T;
-}
+export type ExtractErr<Y> = Y extends Err<unknown, infer U> ? U : never;
 
-export interface Err<E> extends Typed<"Err"> {
-  readonly ok: false;
-  readonly error: E;
-}
+export const ok = Result.ok;
+export const err = Result.err;
 
-/**
- * Discriminated result of operation execution.
- *
- * When `ok` is `true`, read `value`. When `ok` is `false`, read `error`.
- */
-export type Result<T, E> = Ok<T> | Err<E>;
-
-export type ExtractErr<Y> = Y extends Err<infer U> ? U : never;
-
-export const ok = <T>(value: T): Ok<T> => Object.freeze({ type: "Ok", ok: true, value });
-export const err = <E>(error: E): Err<E> => Object.freeze({ type: "Err", ok: false, error });
+export type { Ok, Err };
+export { Result };

--- a/src/typed.ts
+++ b/src/typed.ts
@@ -1,3 +1,3 @@
 export interface Typed<TypeName extends string> {
-  readonly type: TypeName;
+  readonly _tag: TypeName;
 }


### PR DESCRIPTION
## Summary

switches result and typed error model to [`better-result`](https://github.com/dmmulroy/better-result) so callers use one consistent contract instead of a custom in-repo result shape.

- adds `better-result` as a runtime dependency and re-exports its `Result`/`Ok`/`Err` primitives through the library surface
- replaces `TypedError` and `UnexpectedError` usage with `TaggedError` and `UnhandledException`, and aligns discriminators on `_tag`
- updates combinators, core flows, tests, examples, and README guidance to use `isOk()` / `isErr()` checks and the renamed error types
- renames the flagship webhook example to `examples/webhook.ts` and updates smoke/docs references

## Validation Steps

- run `npm run check`