### PR TITLE
improve op extensibility and simplify dependency-aware programs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - For issue hierarchies, prefers real GitHub parent/sub-issue links over markdown-only checklists.
 - Wants issue-work flows to keep `packages/op/CHANGELOG.md` `Unreleased` updated, but prefers to handle version/tag/publish release steps personally unless explicitly delegated.
 - Prefers hard-cutover transitions, not gradual deprecations and migrations (this project is in alpha, so intentional breaking changes are acceptable)
-- Prefers the library to avoid throws whenever possible (normalize when able, otherwise surface as `Err(UnhandledException)` at run time).
+- Prefers the library to avoid eager throws; normalize when able, otherwise surface failures as `Err(UnhandledException)` at run time.
 
 ## Learned Workspace Facts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,4 +36,5 @@
 - The project is currently alpha-stage with no production users, so intentional breaking changes are acceptable.
 - Workspace taxonomy: `packages/*` (publishable), `examples` (`@prodkit/examples`, consumer smoke workspace), `benchmarks/*` (performance harnesses), `tools` (`@prodkit/tools`, maintainer scripts), and `apps/*` reserved for runnable product/demo apps.
 - `@prodkit/std` is the standard-library package; dependency-injection helpers are imported directly from `@prodkit/std/di` and exposed as `di` on root namespace imports.
+- Root `pnpm run gate` runs Turborepo in two phases: `build`, `typecheck`, `test`, `lint`, and `fmt:check` first (upstream `build` before downstream `typecheck`), then `@prodkit/tools` pack smoke only; do not run `examples#smoke` in gate -- it races workspace `dist/` with tools smoke rebuilds and is already covered by the tools pack harness.
 - GitHub repository canonical path is `trvswgnr/prodkit` (renamed from `trvswgnr/op`).

--- a/benchmarks/op/package.json
+++ b/benchmarks/op/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "bench": "node ./bench.ts",
-    "gate": "pnpm run typecheck && pnpm run lint && pnpm run fmt:check",
     "fmt": "oxfmt \"**/*.ts\"",
     "fmt:check": "oxfmt --check \"**/*.ts\"",
     "lint": "oxlint --config ../../oxlint.config.ts .",

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,7 +4,6 @@
   "description": "Consumer-level smoke checks and runnable examples for @prodkit/op and @prodkit/std.",
   "type": "module",
   "scripts": {
-    "gate": "pnpm run typecheck && pnpm run lint && pnpm run fmt:check && pnpm run smoke",
     "fmt": "oxfmt \"**/*.ts\"",
     "fmt:check": "oxfmt --check \"**/*.ts\"",
     "lint": "oxlint --config ../oxlint.config.ts .",

--- a/examples/std/onboarding.ts
+++ b/examples/std/onboarding.ts
@@ -1,5 +1,5 @@
 import { DI } from "@prodkit/std/di";
-import { InferOpMeta, Op } from "@prodkit/op";
+import { Op } from "@prodkit/op";
 import { TaggedError } from "better-result";
 
 export class DuplicateEmailError extends TaggedError("DuplicateEmailError")<{

--- a/examples/std/onboarding.ts
+++ b/examples/std/onboarding.ts
@@ -1,5 +1,5 @@
 import { DI } from "@prodkit/std/di";
-import { Op } from "@prodkit/op";
+import { InferOpMeta, Op } from "@prodkit/op";
 import { TaggedError } from "better-result";
 
 export class DuplicateEmailError extends TaggedError("DuplicateEmailError")<{

--- a/examples/std/onboarding.ts
+++ b/examples/std/onboarding.ts
@@ -49,12 +49,12 @@ export class PasswordHasherService extends DI.Dependency("PasswordHasherService"
 export class MailerService extends DI.Dependency("MailerService")<Mailer> {}
 export class ClockService extends DI.Dependency("ClockService")<Clock> {}
 
-export const loadExistingUser = DI.Op(function* (email: string) {
+export const loadExistingUser = Op(function* (email: string) {
   const db = yield* DI.require(DatabaseService);
   return yield* db.findUserByEmail(email);
 });
 
-export const registerUser = DI.Op(function* (email: string, password: string) {
+export const registerUser = Op(function* (email: string, password: string) {
   const existing = yield* loadExistingUser(email);
   if (existing !== undefined) {
     return yield* new DuplicateEmailError({ email });
@@ -133,7 +133,8 @@ export function createExampleDependencies() {
 
 export function runnableRegisterUser() {
   const services = createExampleDependencies();
-  const op = registerUser.use(
+  const op = DI.provide(
+    registerUser,
     services.db, //
     services.hasher,
     services.mailer,

--- a/examples/std/onboarding.ts
+++ b/examples/std/onboarding.ts
@@ -50,7 +50,7 @@ export class MailerService extends DI.Dependency("MailerService")<Mailer> {}
 export class ClockService extends DI.Dependency("ClockService")<Clock> {}
 
 export const loadExistingUser = Op(function* (email: string) {
-  const db = yield* DI.require(DatabaseService);
+  const db = yield* DI.inject(DatabaseService);
   return yield* db.findUserByEmail(email);
 });
 
@@ -60,10 +60,10 @@ export const registerUser = Op(function* (email: string, password: string) {
     return yield* new DuplicateEmailError({ email });
   }
 
-  const db = yield* DI.require(DatabaseService);
-  const hasher = yield* DI.require(PasswordHasherService);
-  const mailer = yield* DI.require(MailerService);
-  const clock = yield* DI.require(ClockService);
+  const db = yield* DI.inject(DatabaseService);
+  const hasher = yield* DI.inject(PasswordHasherService);
+  const mailer = yield* DI.inject(MailerService);
+  const clock = yield* DI.inject(ClockService);
 
   const passwordHash = yield* hasher.hash(password);
   const createdAt = yield* clock.nowIso;

--- a/examples/std/smoke.ts
+++ b/examples/std/smoke.ts
@@ -5,6 +5,7 @@ import {
   runnableRegisterUser,
 } from "./onboarding.ts";
 import { assert } from "../assert.ts";
+import { DI } from "@prodkit/std/di";
 
 async function runSuccessfulRegistrationSmoke() {
   const { op, services } = runnableRegisterUser();
@@ -23,7 +24,13 @@ async function runSuccessfulRegistrationSmoke() {
 
 async function runDuplicateRegistrationSmoke() {
   const services = createExampleDependencies();
-  const op = registerUser.use(services.db).use(services.hasher, services.mailer, services.clock);
+  const op = DI.provide(
+    registerUser,
+    services.db,
+    services.hasher,
+    services.mailer,
+    services.clock,
+  );
 
   const first = await op.run("existing@example.test", "first");
   assert(first.isOk(), "first registration should succeed");

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -9,7 +9,8 @@
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "noErrorTruncation": true
   },
   "include": ["./**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "turbo run lint --log-order=grouped",
     "fmt": "turbo run fmt --log-order=grouped",
     "fmt:check": "turbo run fmt:check --log-order=grouped",
-    "gate": "turbo run gate --log-order=grouped",
+    "gate": "turbo run build typecheck test lint fmt:check --log-order=grouped && turbo run smoke --filter=@prodkit/tools --log-order=grouped",
     "bench": "turbo run bench --filter=@prodkit/op-benchmarks --log-order=grouped",
     "clean": "git clean -Xfd"
   },

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for runtime-agnostic extension code.
 - Added regression coverage for generator-built operation callback sequencing without relying on
   function arity reflection.
+- Added the internal namespaced `NEEDS` metadata latch for extension packages, exported
+  `Needs(..., namespace)` / `NeedsOp` for marking operations that are not ready to run, and kept
+  `IsRunnable<M>`, `SetNeedsNamespace`, and `ClearNeedsNamespace` on `@prodkit/op/internal` for
+  extension inference.
 
 ### Changed
 
@@ -37,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{ readonly requirements: A | B }`) instead of a union of per-op metadata objects.
 - Fixed `InferOpMeta` inference for ops with runtime arguments; it now matches any args tuple instead
   of requiring `readonly unknown[]`.
+- `.run()` and `Op.run(...)` are available by default and blocked when operation metadata
+  carries any namespaced needs latch entry or the op was wrapped with `Needs(..., namespace)`.
 
 ## [0.1.68] - 2026-05-15
 

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the phantom `_E` type parameter from `CustomInstruction`; typed generator errors are inferred
+  only from yielded `Err` values and nested ops. Extension metadata remains on `M`.
 - Consolidated consumer examples into `examples/` (`@prodkit/examples`); consumer smoke now
   validates packed installs for both `@prodkit/op` and `@prodkit/std`.
 - Flattened maintainer scripts workspace from `tools/op` to `tools/` and renamed it to

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   op factories are treated as plain values unless they are explicitly invoked.
 - Preserved or merged operation metadata through fluent combinators so extension metadata survives
   `map`, `mapErr`, policies, lifecycle hooks, `flatMap`, `tap`, `tapErr`, and `recover`.
+- Replaced DI-specific metadata merge with generic key-level `MergeMeta` that unions values at
+  shared keys, so composed ops keep one metadata object (for example
+  `{ readonly requirements: A | B }`) instead of a union of per-op metadata objects.
+- Fixed `InferOpMeta` inference for ops with runtime arguments; it now matches any args tuple instead
+  of requiring `readonly unknown[]`.
 
 ## [0.1.68] - 2026-05-15
 

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -17,10 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for runtime-agnostic extension code.
 - Added regression coverage for generator-built operation callback sequencing without relying on
   function arity reflection.
-- Added the internal namespaced `NEEDS` metadata latch for extension packages, exported
-  `Needs(..., namespace)` / `NeedsOp` for marking operations that are not ready to run, and kept
-  `IsRunnable<M>`, `SetNeedsNamespace`, and `ClearNeedsNamespace` on `@prodkit/op/internal` for
-  extension inference.
+- Added the generic `Blocking<T>` metadata brand for extension packages, exported
+  `withBlocking(..., key)` / `BlockingOp` for marking operations that are not ready to run, and kept
+  `IsRunnable<M>` and `SetBlockingMeta` on `@prodkit/op/internal` for extension inference.
 
 ### Changed
 
@@ -42,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `InferOpMeta` inference for ops with runtime arguments; it now matches any args tuple instead
   of requiring `readonly unknown[]`.
 - `.run()` and `Op.run(...)` are available by default and blocked when operation metadata
-  carries any namespaced needs latch entry or the op was wrapped with `Needs(..., namespace)`.
+  carries any unsatisfied `Blocking<T>` value or the op was wrapped with `withBlocking(..., key)`.
 
 ## [0.1.68] - 2026-05-15
 

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the generic `Op<T, E, A, M>` metadata slot, branded `EmptyMeta`, metadata inference helpers,
+  and custom-instruction metadata inference for extension packages.
 - Added `@prodkit/op/internal` entry for low-level helpers shared with extension packages
   (for example `@prodkit/std`).
 - Exported `AbortSignalLike`, `functionHasTruthyBrand`, and `NEVER` via `@prodkit/op/internal`
@@ -26,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real `AbortSignal` implementations).
 - Changed fluent callback sequencing to drive only bound nullary ops, so returned generator-built
   op factories are treated as plain values unless they are explicitly invoked.
+- Preserved or merged operation metadata through fluent combinators so extension metadata survives
+  `map`, `mapErr`, policies, lifecycle hooks, `flatMap`, `tap`, `tapErr`, and `recover`.
 
 ## [0.1.68] - 2026-05-15
 

--- a/packages/op/package.json
+++ b/packages/op/package.json
@@ -45,7 +45,6 @@
   "scripts": {
     "build": "tsdown",
     "changelog:check": "node ../../tools/check-changelog-version.ts",
-    "gate": "pnpm run build && pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run fmt:check",
     "fix": "pnpm run lint:fix && pnpm run fmt",
     "fmt": "oxfmt \"src/**/*.ts\" \"*.ts\"",
     "fmt:check": "oxfmt --check \"src/**/*.ts\" \"*.ts\"",

--- a/packages/op/src/blocking.ts
+++ b/packages/op/src/blocking.ts
@@ -1,26 +1,31 @@
 import { unsafeCoerce } from "./shared.js";
-import { type EmptyMeta, type OpInterface, type SetNeedsNamespace } from "./core/types.js";
+import { type EmptyMeta, type OpInterface, type SetBlockingMeta } from "./core/types.js";
 import type { Tagged } from "./tagged.js";
 
 type OpType<T, E, A extends readonly unknown[], M> = OpInterface<T, E, A, M> & Tagged<"Op">;
 
 /** An operation that is not ready for top-level `.run()`. */
-export type NeedsOp<
+export type BlockingOp<
   T,
   E,
   A extends readonly unknown[],
   M = EmptyMeta,
-  NS extends string = string,
-> = OpType<T, E, A, SetNeedsNamespace<M, NS>>;
+  K extends PropertyKey = string,
+  P = true,
+> = OpType<T, E, A, SetBlockingMeta<M, K, P>>;
 
 /**
  * Marks an operation as needing extension-specific preconditions before
- * top-level `.run()`.
+ * top-level `.run()` by placing `Blocking<P>` on a metadata key.
  */
-export function Needs<T, E, A extends readonly unknown[], M, const NS extends string>(
-  op: OpType<T, E, A, M>,
-  _namespace: NS,
-): NeedsOp<T, E, A, M, NS> {
+export function withBlocking<
+  T,
+  E,
+  A extends readonly unknown[],
+  M,
+  const K extends PropertyKey,
+  P = true,
+>(op: OpType<T, E, A, M>, _key: K): BlockingOp<T, E, A, M, K, P> {
   // SAFETY: type-only metadata transition; runtime op behavior is unchanged.
   return unsafeCoerce(op);
 }

--- a/packages/op/src/builders.ts
+++ b/packages/op/src/builders.ts
@@ -1,19 +1,28 @@
+// oxlint-disable typescript-eslint/no-explicit-any
 import { UnhandledException } from "./errors.js";
 import { makeFluentOp, onOp } from "./core/fluent.js";
-import type { TrackedErr, AnyExitFn, Instruction, OpInterface } from "./core/types.js";
+import type {
+  AnyExitFn,
+  EmptyMeta,
+  InferInstructionErr,
+  InferInstructionMeta,
+  Instruction,
+  OpInterface,
+  TrackedErr,
+} from "./core/types.js";
 import type { Op } from "./index.js";
 import { RegisterExitFinalizerInstruction, SuspendInstruction } from "./core/instructions.js";
 import { withRetryOp, withTimeoutOp, withSignalOp } from "./policies.js";
-import { Result, type InferErr } from "./result.js";
+import { Result } from "./result.js";
 import { makeCoreOp, createDefaultHooks, withCleanupCoreOp } from "./core/fluent.js";
 import { unsafeCoerce, isAwaited, sleepWithSignal } from "./shared.js";
 
-export function succeed<T>(value: T | PromiseLike<T>): Op<Awaited<T>, never, []> {
+export function succeed<T>(value: T | PromiseLike<T>): Op<Awaited<T>, never, [], EmptyMeta> {
   if (!isAwaited(value)) {
     return _try(() => value);
   }
 
-  const op: Op<Awaited<T>, never, []> = makeCoreOp(
+  const op: Op<Awaited<T>, never, [], EmptyMeta> = makeCoreOp(
     function* () {
       return value;
     },
@@ -26,8 +35,8 @@ export function succeed<T>(value: T | PromiseLike<T>): Op<Awaited<T>, never, []>
 /*
  * Lifts a value into an operation that always fails
  */
-export function fail<E>(value: E): Op<never, E, []> {
-  const op: Op<never, E, []> = makeCoreOp(
+export function fail<E>(value: E): Op<never, E, [], EmptyMeta> {
+  const op: Op<never, E, [], EmptyMeta> = makeCoreOp(
     function* () {
       return yield* Result.err(value);
     },
@@ -37,8 +46,8 @@ export function fail<E>(value: E): Op<never, E, []> {
   return op;
 }
 
-export function defer(finalize: AnyExitFn): Op<void, never, []> {
-  const op: Op<void, never, []> = makeCoreOp(
+export function defer(finalize: AnyExitFn): Op<void, never, [], EmptyMeta> {
+  const op: Op<void, never, [], EmptyMeta> = makeCoreOp(
     function* () {
       yield new RegisterExitFinalizerInstruction((ctx) =>
         Promise.resolve(finalize(ctx)).then(() => {}),
@@ -49,7 +58,7 @@ export function defer(finalize: AnyExitFn): Op<void, never, []> {
   return op;
 }
 
-export function sleep(ms: number): Op<void, never, []> {
+export function sleep(ms: number): Op<void, never, [], EmptyMeta> {
   return _try((signal) => sleepWithSignal(ms, signal));
 }
 
@@ -62,8 +71,8 @@ export function sleep(ms: number): Op<void, never, []> {
 export function _try<T, E = UnhandledException>(
   f: (signal: AbortSignal) => T,
   onError?: (e: unknown) => E | PromiseLike<E>,
-): Op<Awaited<T>, TrackedErr<Awaited<E>>, []> {
-  const op: Op<Awaited<T>, TrackedErr<Awaited<E>>, []> = makeCoreOp(
+): Op<Awaited<T>, TrackedErr<Awaited<E>>, [], EmptyMeta> {
+  const op: Op<Awaited<T>, TrackedErr<Awaited<E>>, [], EmptyMeta> = makeCoreOp(
     function* () {
       const result: Result<
         Awaited<T>,
@@ -89,13 +98,13 @@ export function _try<T, E = UnhandledException>(
   return op;
 }
 
-function bindArityArgsToFinalizers<T>(
-  iterator: Generator<Instruction<unknown>, T, unknown>,
+function bindArityArgsToFinalizers<T, M>(
+  iterator: Generator<Instruction<unknown, M>, T, unknown>,
   args: readonly unknown[],
-): Generator<Instruction<unknown>, T, unknown> {
+): Generator<Instruction<unknown, M>, T, unknown> {
   const bindStep = (
-    step: IteratorResult<Instruction<unknown>, T>,
-  ): IteratorResult<Instruction<unknown>, T> => {
+    step: IteratorResult<Instruction<unknown, M>, T>,
+  ): IteratorResult<Instruction<unknown, M>, T> => {
     if (step.done) return step;
     if (!(step.value instanceof RegisterExitFinalizerInstruction)) return step;
     if (step.value.args !== undefined) return step;
@@ -121,10 +130,10 @@ function bindArityArgsToFinalizers<T>(
   };
 }
 
-function makeArityOp<T, E, A extends readonly unknown[]>(
-  invoke: (...args: A) => Op<T, E, []>,
-  makeIterable?: () => Op<T, E, []>,
-): OpInterface<T, E, A> {
+function makeArityOp<T, E, A extends readonly unknown[], M = EmptyMeta>(
+  invoke: (...args: A) => Op<T, E, [], M>,
+  makeIterable?: () => Op<T, E, [], M>,
+): OpInterface<T, E, A, M> {
   return makeFluentOp(
     invoke,
     (self) => ({
@@ -157,18 +166,18 @@ function makeArityOp<T, E, A extends readonly unknown[]>(
 /**
  * Turns a generator function into an {@link Op}
  */
-export function fromGenFn<Y extends Instruction<unknown>, T, A extends readonly unknown[]>(
+export function fromGenFn<Y extends Instruction<any, any>, T, A extends readonly unknown[]>(
   f: (...args: A) => Generator<Y, T, unknown>,
-): Op<T, InferErr<Y>, A> {
+): Op<T, InferInstructionErr<Y>, A, InferInstructionMeta<Y>> {
   // We intentionally always build through the tuple-arity lifting path, including for `A = []`.
   // This keeps runtime behavior uniform while preserving exact tuple signatures at the type level.
   const invoke = (...args: A) => {
-    const bound: Op<T, InferErr<Y>, []> = makeCoreOp(
+    const bound: Op<T, InferInstructionErr<Y>, [], InferInstructionMeta<Y>> = makeCoreOp(
       () =>
         // SAFETY: TS cannot model `Generator<Y, T, unknown>` as the internal instruction supertype.
-        unsafeCoerce<Generator<Instruction<InferErr<Y>>, T, unknown>>(
-          bindArityArgsToFinalizers(f(...args), args),
-        ),
+        unsafeCoerce<
+          Generator<Instruction<InferInstructionErr<Y>, InferInstructionMeta<Y>>, T, unknown>
+        >(bindArityArgsToFinalizers(f(...args), args)),
       createDefaultHooks(() => bound),
     );
     return bound;
@@ -181,5 +190,6 @@ export function fromGenFn<Y extends Instruction<unknown>, T, A extends readonly 
     ),
   );
 
-  return op;
+  // SAFETY: makeArityOp preserves runtime behavior; the cast restores metadata inferred from Y.
+  return unsafeCoerce<Op<T, InferInstructionErr<Y>, A, InferInstructionMeta<Y>>>(op);
 }

--- a/packages/op/src/builders.ts
+++ b/packages/op/src/builders.ts
@@ -190,6 +190,5 @@ export function fromGenFn<Y extends Instruction<any, any>, T, A extends readonly
     ),
   );
 
-  // SAFETY: makeArityOp preserves runtime behavior; the cast restores metadata inferred from Y.
-  return unsafeCoerce<Op<T, InferInstructionErr<Y>, A, InferInstructionMeta<Y>>>(op);
+  return op;
 }

--- a/packages/op/src/combinators.ts
+++ b/packages/op/src/combinators.ts
@@ -1,3 +1,4 @@
+// oxlint-disable typescript-eslint/no-explicit-any
 import { ErrorGroup, UnhandledException } from "./errors.js";
 import {
   type Instruction,
@@ -11,7 +12,7 @@ import { createRunContext, drive } from "./core/runtime.js";
 import { Result, type Err } from "./result.js";
 import { makeCoreOp, createDefaultHooks } from "./core/fluent.js";
 
-type AnyNullaryOp = Op<unknown, unknown, []>;
+type AnyNullaryOp = Op<any, any, [], any>;
 
 function makeCombinatorOp<T, E>(gen: () => Generator<Instruction<E>, T, unknown>): Op<T, E, []> {
   const self: Op<T, E, []> = makeCoreOp(
@@ -47,7 +48,7 @@ function fanOut<T, E>(
   const detach = () => outerContext.signal.removeEventListener("abort", cascade);
   const controllers = entries.map((e) => e.controller);
   const runs = entries.map((e) =>
-    drive(e.op, createRunContext(e.controller.signal, outerContext.args)),
+    drive(e.op, createRunContext(e.controller.signal, outerContext.args, outerContext.extensions)),
   );
 
   return { runs, controllers, detach };
@@ -164,7 +165,10 @@ async function driveAll<T, E>(
       const controller = new AbortController();
       controllers.add(controller);
       if (outerContext.signal.aborted) controller.abort(outerContext.signal.reason);
-      const res = await drive(op, createRunContext(controller.signal, outerContext.args));
+      const res = await drive(
+        op,
+        createRunContext(controller.signal, outerContext.args, outerContext.extensions),
+      );
       controllers.delete(controller);
       results[i] = res;
       if (res.isErr() && firstErr === undefined) {
@@ -287,7 +291,10 @@ async function driveAllSettled<T, E>(
       const controller = new AbortController();
       controllers.add(controller);
       if (outerContext.signal.aborted) controller.abort(outerContext.signal.reason);
-      results[i] = await drive(op, createRunContext(controller.signal, outerContext.args));
+      results[i] = await drive(
+        op,
+        createRunContext(controller.signal, outerContext.args, outerContext.extensions),
+      );
       controllers.delete(controller);
     }
   };

--- a/packages/op/src/core.test.ts
+++ b/packages/op/src/core.test.ts
@@ -6,13 +6,43 @@ import {
   RegisterExitFinalizerInstruction,
   SuspendInstruction,
 } from "./core/instructions.js";
-import type { Instruction } from "./core/types.js";
-import type { Op } from "./index.js";
+import {
+  CUSTOM_INSTRUCTION_META,
+  type CustomInstruction,
+  type EmptyMeta,
+  type Instruction,
+  type RunContext,
+} from "./core/types.js";
+import { Op, type Op as OpType } from "./index.js";
 import { UnhandledException } from "./errors.js";
 import { Result } from "./result.js";
 
-function makeRuntimeOp<T, E>(gen: () => Generator<Instruction<E>, T, unknown>): Op<T, E, []> {
-  const op: Op<T, E, []> = makeCoreOp(gen, {
+class ThrowingCustomInstruction implements CustomInstruction<never, EmptyMeta> {
+  readonly [CUSTOM_INSTRUCTION_META] = undefined as unknown as EmptyMeta;
+
+  resolve(_context: RunContext): never {
+    throw new Error("resolve-threw");
+  }
+
+  *[Symbol.iterator](): Generator<this, never, unknown> {
+    return (yield this) as never;
+  }
+}
+
+class RejectingCustomInstruction implements CustomInstruction<never, EmptyMeta> {
+  readonly [CUSTOM_INSTRUCTION_META] = undefined as unknown as EmptyMeta;
+
+  resolve(_context: RunContext): Promise<never> {
+    return Promise.reject(new Error("resolve-rejected"));
+  }
+
+  *[Symbol.iterator](): Generator<this, never, unknown> {
+    return (yield this) as never;
+  }
+}
+
+function makeRuntimeOp<T, E>(gen: () => Generator<Instruction<E>, T, unknown>): OpType<T, E, []> {
+  const op: OpType<T, E, []> = makeCoreOp(gen, {
     withRelease: (_release) => op,
     registerEnterInitialize: (_initialize) => op,
     registerExitFinalize: (_finalize) => op,
@@ -88,6 +118,34 @@ describe("drive runtime behavior", () => {
     assert(result.isOk(), "result should be Ok");
     expect(result.value).toBe(70);
     expect(seenSignal).toBe(signal);
+  });
+
+  test("resumeCustom converts a thrown resolve into Err(UnhandledException)", async () => {
+    const op: OpType<never, never, []> = Op(function* () {
+      return yield* new ThrowingCustomInstruction();
+    });
+
+    const result = await op.run();
+
+    assert(result.isErr(), "result should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
+    const cause = (result.error as UnhandledException).cause;
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).message).toBe("resolve-threw");
+  });
+
+  test("resumeCustom converts a rejected resolve into Err(UnhandledException)", async () => {
+    const op: OpType<never, never, []> = Op(function* () {
+      return yield* new RejectingCustomInstruction();
+    });
+
+    const result = await op.run();
+
+    assert(result.isErr(), "result should be Err");
+    expect(result.error).toBeInstanceOf(UnhandledException);
+    const cause = (result.error as UnhandledException).cause;
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).message).toBe("resolve-rejected");
   });
 
   test("invalid yielded instructions return Err(UnhandledException(TypeError))", async () => {

--- a/packages/op/src/core/fluent.ts
+++ b/packages/op/src/core/fluent.ts
@@ -490,7 +490,7 @@ export interface FluentHandlers<T, E, A extends readonly unknown[]> {
  * @warning This function is UNSAFE and should be used only when the type is known to be correct.
  */
 export function asOpInterface<T, E, A extends readonly unknown[], Yieldable extends boolean>(
-  op: Op<T, E, A, Yieldable>,
+  op: Op<T, E, A>,
 ): OpInterface<T, E, A, Yieldable> {
   // SAFETY: Op<T, E, A> is the public branded intersection over OpInterface<T, E, A>.
   return unsafeCoerce(op);

--- a/packages/op/src/core/fluent.ts
+++ b/packages/op/src/core/fluent.ts
@@ -582,10 +582,17 @@ export function makeFluentOp<
       tapErr: <R>(observe: (error: E) => R) =>
         liftOp(
           self,
-          (resolved) => tapErrCoreOp(resolved, observe),
           (resolved) =>
-            tapErrCoreOp(resolved, (error) =>
-              TimeoutError.is(error) ? undefined : observe(error),
+            // SAFETY: tapErr metadata matches the timeout-filtered observer path.
+            unsafeCoerce<Op<T, E | InferOpErr<R>, [], MergeMeta<M, InferOpMeta<R>>>>(
+              tapErrCoreOp(resolved, observe),
+            ),
+          (resolved) =>
+            // SAFETY: tapErr metadata matches the timeout-filtered observer path.
+            unsafeCoerce<Op<T, E | InferOpErr<R> | TimeoutError, [], MergeMeta<M, InferOpMeta<R>>>>(
+              tapErrCoreOp(resolved, (error) =>
+                TimeoutError.is(error) ? undefined : observe(error),
+              ),
             ),
         ),
       recover: <R>(predicate: (error: E) => boolean, handler: (error: E) => R) =>

--- a/packages/op/src/core/fluent.ts
+++ b/packages/op/src/core/fluent.ts
@@ -1,3 +1,4 @@
+// oxlint-disable typescript-eslint/no-explicit-any
 import { TimeoutError, UnhandledException } from "../errors.js";
 import { Result } from "../result.js";
 import { withRetryOp, withSignalOp, withTimeoutOp, type RetryPolicy } from "../policies.js";
@@ -6,12 +7,15 @@ import type {
   EnterFn,
   ExitContext,
   ExitFn,
+  EmptyMeta,
   OpInterface,
   Instruction,
   LifecycleFn,
+  MergeMeta,
   OpHooks,
   OpLifecycleHook,
   InferOpErr,
+  InferOpMeta,
   InferOpOk,
   ReleaseFn,
   TrackedErr,
@@ -34,11 +38,11 @@ function conditionalPredicate<E>(pred: ((error: E) => boolean) | WithPredicateMe
   return "is" in pred ? pred.is(error) : pred(error);
 }
 
-function dispatchLifecycleCore<T, E>(
-  hooks: OpHooks<T, E>,
+function dispatchLifecycleCore<T, E, M>(
+  hooks: OpHooks<T, E, M>,
   event: OpLifecycleHook,
   handler: LifecycleFn<T, E, []>,
-): Op<T, E, []> {
+): Op<T, E, [], M> {
   const hookName = event === "enter" ? "registerEnterInitialize" : "registerExitFinalize";
   const hook = hooks[hookName];
 
@@ -52,12 +56,12 @@ function dispatchLifecycleCore<T, E>(
   );
 }
 
-type DefaultHooks<T, E> = Pick<
-  OpHooks<T, E>,
+type DefaultHooks<T, E, M> = Pick<
+  OpHooks<T, E, M>,
   "withRelease" | "registerEnterInitialize" | "registerExitFinalize"
 >;
 
-export function createDefaultHooks<T, E>(getSelf: () => Op<T, E, []>): DefaultHooks<T, E> {
+export function createDefaultHooks<T, E, M>(getSelf: () => Op<T, E, [], M>): DefaultHooks<T, E, M> {
   return {
     withRelease: (release) => withCleanupCoreOp(getSelf(), release),
     registerEnterInitialize: (initialize) => onEnterCoreOp(getSelf(), initialize),
@@ -65,11 +69,11 @@ export function createDefaultHooks<T, E>(getSelf: () => Op<T, E, []>): DefaultHo
   };
 }
 
-export function makeCoreOp<T, E>(
-  gen: () => Generator<Instruction<E>, T, unknown>,
-  hooks: OpHooks<T, E>,
-): Op<T, TrackedErr<E>, []> {
-  let self: Op<T, TrackedErr<E>, []>;
+export function makeCoreOp<T, E, M = EmptyMeta>(
+  gen: () => Generator<Instruction<E, M>, T, unknown>,
+  hooks: OpHooks<T, E, M>,
+): Op<T, TrackedErr<E>, [], M> {
+  let self: Op<T, TrackedErr<E>, [], M>;
   const hasPushThroughConfig = hooks.inner !== undefined && hooks.rebuild !== undefined;
   const pushInner = hooks.inner;
   const rebuild = hooks.rebuild;
@@ -100,7 +104,7 @@ export function makeCoreOp<T, E>(
       dispatchLifecycleCore(hooks, event, handler),
     map: <U>(transform: (value: T) => U) => mapCoreOp(self, transform),
     mapErr: <E2>(transform: (error: E) => E2) => mapErrCoreOp(self, transform),
-    flatMap: <U, E2>(bind: (value: T) => Op<U, E2, []>) => flatMapCoreOp(self, bind),
+    flatMap: <R extends Op<any, any, [], any>>(bind: (value: T) => R) => flatMapCoreOp(self, bind),
     tap: <R>(observe: (value: T) => R) => tapCoreOp(self, observe),
     tapErr: <R>(observe: (error: E) => R) => tapErrCoreOp(self, observe),
     recover: <R>(predicate: (error: E) => boolean, handler: (error: E) => R) =>
@@ -119,8 +123,11 @@ export function makeCoreOp<T, E>(
   return self;
 }
 
-export function withCleanupCoreOp<T, E>(op: Op<T, E, []>, release: ReleaseFn<T>): Op<T, E, []> {
-  return makeCoreOp(
+export function withCleanupCoreOp<T, E, M>(
+  op: Op<T, E, [], M>,
+  release: ReleaseFn<T>,
+): Op<T, E, [], M> {
+  return makeCoreOp<T, E | UnhandledException, M>(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -139,7 +146,7 @@ export function withCleanupCoreOp<T, E>(op: Op<T, E, []>, release: ReleaseFn<T>)
       rebuild: (newInner) =>
         withCleanupCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook.
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           release,
         ),
       withRelease: (nextRelease) => withCleanupCoreOp(withCleanupCoreOp(op, release), nextRelease),
@@ -150,8 +157,11 @@ export function withCleanupCoreOp<T, E>(op: Op<T, E, []>, release: ReleaseFn<T>)
   );
 }
 
-export function onEnterCoreOp<T, E>(op: Op<T, E, []>, initialize: EnterFn<[]>): Op<T, E, []> {
-  return makeCoreOp(
+export function onEnterCoreOp<T, E, M>(
+  op: Op<T, E, [], M>,
+  initialize: EnterFn<[]>,
+): Op<T, E, [], M> {
+  return makeCoreOp<T, E | UnhandledException, M>(
     function* () {
       yield new SuspendInstruction(async (context) => {
         const enterCtx: EnterContext<[]> = { signal: context.signal, args: EMPTY_TUPLE };
@@ -171,7 +181,7 @@ export function onEnterCoreOp<T, E>(op: Op<T, E, []>, initialize: EnterFn<[]>): 
       rebuild: (newInner) =>
         onEnterCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook.
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           initialize,
         ),
       withRelease: (release) => withCleanupCoreOp(onEnterCoreOp(op, initialize), release),
@@ -182,8 +192,11 @@ export function onEnterCoreOp<T, E>(op: Op<T, E, []>, initialize: EnterFn<[]>): 
   );
 }
 
-export function onExitCoreOp<T, E>(op: Op<T, E, []>, finalize: ExitFn<T, E, []>): Op<T, E, []> {
-  return makeCoreOp(
+export function onExitCoreOp<T, E, M>(
+  op: Op<T, E, [], M>,
+  finalize: ExitFn<T, E, []>,
+): Op<T, E, [], M> {
+  return makeCoreOp<T, E | UnhandledException, M>(
     function* () {
       yield new RegisterExitFinalizerInstruction(async (ctx) => {
         const exitCtx: ExitContext<T, E, []> = {
@@ -208,13 +221,13 @@ export function onExitCoreOp<T, E>(op: Op<T, E, []>, finalize: ExitFn<T, E, []>)
       rebuild: (newInner) =>
         onExitCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           finalize,
         ),
       rebuildForTimeout: (newInner) =>
         onExitCoreOp(
           // SAFETY: timeout push-through widens inner error type, so widen finalize accordingly.
-          unsafeCoerce<Op<T, E | TimeoutError, []>>(newInner),
+          unsafeCoerce<Op<T, E | TimeoutError, [], M>>(newInner),
           // SAFETY: TimeoutError is filtered before `finalize`, so it still only receives `E`.
           unsafeCoerce(finalize),
         ),
@@ -228,10 +241,18 @@ export function onExitCoreOp<T, E>(op: Op<T, E, []>, finalize: ExitFn<T, E, []>)
 }
 
 export function mapCoreOp<T, E, U>(
-  op: Op<T, E, []>,
+  op: Op<T, E, [], EmptyMeta>,
   transform: (value: T) => U,
-): Op<Awaited<U>, E, []> {
-  return makeCoreOp(
+): Op<Awaited<U>, E, [], EmptyMeta>;
+export function mapCoreOp<T, E, U, M>(
+  op: Op<T, E, [], M>,
+  transform: (value: T) => U,
+): Op<Awaited<U>, E, [], M>;
+export function mapCoreOp<T, E, U, M>(
+  op: Op<T, E, [], M>,
+  transform: (value: T) => U,
+): Op<Awaited<U>, E, [], M> {
+  return makeCoreOp<Awaited<U>, E | UnhandledException, M>(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -252,18 +273,22 @@ export function mapCoreOp<T, E, U>(
       rebuild: (newInner) =>
         mapCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook.
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           transform,
         ),
     },
   );
 }
 
-export function flatMapCoreOp<T, E, U, E2>(
-  op: Op<T, E, []>,
-  bind: (value: T) => Op<U, E2, []>,
-): Op<U, E | E2, []> {
-  const mapped: Op<U, E | E2, []> = makeCoreOp<U, E | E2 | UnhandledException>(
+export function flatMapCoreOp<T, E, R extends Op<any, any, [], any>, M>(
+  op: Op<T, E, [], M>,
+  bind: (value: T) => R,
+): Op<InferOpOk<R>, E | InferOpErr<R>, [], MergeMeta<M, InferOpMeta<R>>> {
+  const mapped: Op<InferOpOk<R>, E | InferOpErr<R>, [], MergeMeta<M, InferOpMeta<R>>> = makeCoreOp<
+    InferOpOk<R>,
+    E | InferOpErr<R> | UnhandledException,
+    MergeMeta<M, InferOpMeta<R>>
+  >(
     function* () {
       const first: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -271,9 +296,10 @@ export function flatMapCoreOp<T, E, U, E2>(
 
       if (first.isErr()) return yield* first;
 
-      const second: Result<U, E2 | UnhandledException> = yield* new SuspendInstruction((context) =>
-        drive(bind(first.value), context),
-      );
+      const second: Result<
+        InferOpOk<R>,
+        InferOpErr<R> | UnhandledException
+      > = yield* new SuspendInstruction((context) => drive(bind(first.value), context));
 
       if (second.isErr()) return yield* second;
       return second.value;
@@ -284,11 +310,11 @@ export function flatMapCoreOp<T, E, U, E2>(
   return mapped;
 }
 
-export function tapCoreOp<T, E, R>(
-  op: Op<T, E, []>,
+export function tapCoreOp<T, E, R, M>(
+  op: Op<T, E, [], M>,
   observe: (value: T) => R,
-): Op<T, E | InferOpErr<R>, []> {
-  return makeCoreOp<T, E | InferOpErr<R> | UnhandledException>(
+): Op<T, E | InferOpErr<R>, [], MergeMeta<M, InferOpMeta<R>>> {
+  return makeCoreOp<T, E | InferOpErr<R> | UnhandledException, MergeMeta<M, InferOpMeta<R>>>(
     function* () {
       const source: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -299,7 +325,7 @@ export function tapCoreOp<T, E, R>(
       const observed: R = yield* new SuspendInstruction(() =>
         Promise.resolve(observe(source.value)),
       );
-      const observedOp: Op<unknown, unknown, []> | undefined = yield* new SuspendInstruction(() =>
+      const observedOp: Op<any, any, [], any> | undefined = yield* new SuspendInstruction(() =>
         Promise.resolve(coerceToNullaryOp(observed)),
       );
 
@@ -317,18 +343,18 @@ export function tapCoreOp<T, E, R>(
       rebuild: (newInner) =>
         tapCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook.
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           observe,
         ),
     },
   );
 }
 
-export function tapErrCoreOp<T, E, R>(
-  op: Op<T, E, []>,
+export function tapErrCoreOp<T, E, R, M>(
+  op: Op<T, E, [], M>,
   observe: (error: E) => R,
-): Op<T, E | InferOpErr<R>, []> {
-  return makeCoreOp<T, E | InferOpErr<R> | UnhandledException>(
+): Op<T, E | InferOpErr<R>, [], MergeMeta<M, InferOpMeta<R>>> {
+  return makeCoreOp<T, E | InferOpErr<R> | UnhandledException, MergeMeta<M, InferOpMeta<R>>>(
     function* () {
       const source: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -342,7 +368,7 @@ export function tapErrCoreOp<T, E, R>(
       const observed: R = yield* new SuspendInstruction(() =>
         Promise.resolve(observe(sourceError)),
       );
-      const observedOp: Op<unknown, unknown, []> | undefined = yield* new SuspendInstruction(() =>
+      const observedOp: Op<any, any, [], any> | undefined = yield* new SuspendInstruction(() =>
         Promise.resolve(coerceToNullaryOp(observed)),
       );
 
@@ -360,24 +386,27 @@ export function tapErrCoreOp<T, E, R>(
       rebuild: (newInner) =>
         tapErrCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           observe,
         ),
       rebuildForTimeout: (newInner) =>
-        tapErrCoreOp(
-          // SAFETY: timeout push-through widens only the error channel with TimeoutError.
-          unsafeCoerce<Op<T, E | TimeoutError, []>>(newInner),
-          (error: E | TimeoutError) => (TimeoutError.is(error) ? undefined : observe(error)),
+        // SAFETY: timeout filtering preserves the observer metadata while widening only error type.
+        unsafeCoerce<Op<T, E | TimeoutError, [], MergeMeta<M, InferOpMeta<R>>>>(
+          tapErrCoreOp(
+            // SAFETY: timeout push-through widens only the error channel with TimeoutError.
+            unsafeCoerce<Op<T, E | TimeoutError, [], M>>(newInner),
+            (error: E | TimeoutError) => (TimeoutError.is(error) ? undefined : observe(error)),
+          ),
         ),
     },
   );
 }
 
-export function mapErrCoreOp<T, E, E2>(
-  op: Op<T, E, []>,
+export function mapErrCoreOp<T, E, E2, M>(
+  op: Op<T, E, [], M>,
   transform: (error: E) => E2,
-): Op<T, E2, []> {
-  return makeCoreOp<T, E2 | UnhandledException>(
+): Op<T, E2, [], M> {
+  return makeCoreOp<T, E2 | UnhandledException, M>(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -400,25 +429,29 @@ export function mapErrCoreOp<T, E, E2>(
       rebuild: (newInner) =>
         mapErrCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           transform,
         ),
       rebuildForTimeout: (newInner) =>
         mapErrCoreOp(
           // SAFETY: timeout push-through widens only the error channel with TimeoutError.
-          unsafeCoerce<Op<T, E | TimeoutError, []>>(newInner),
+          unsafeCoerce<Op<T, E | TimeoutError, [], M>>(newInner),
           (error: E | TimeoutError) => (TimeoutError.is(error) ? error : transform(error)),
         ),
     },
   );
 }
 
-export function recoverCoreOp<T, E, R>(
-  op: Op<T, E, []>,
+export function recoverCoreOp<T, E, R, M>(
+  op: Op<T, E, [], M>,
   predicate: ((error: E) => boolean) | WithPredicateMethod<E>,
   handler: (error: E) => R,
-): Op<T | InferOpOk<R>, E | InferOpErr<R>, []> {
-  return makeCoreOp<T | InferOpOk<R>, E | InferOpErr<R> | UnhandledException>(
+): Op<T | InferOpOk<R>, E | InferOpErr<R>, [], MergeMeta<M, InferOpMeta<R>>> {
+  return makeCoreOp<
+    T | InferOpOk<R>,
+    E | InferOpErr<R> | UnhandledException,
+    MergeMeta<M, InferOpMeta<R>>
+  >(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction((context) =>
         drive(op, context),
@@ -435,7 +468,7 @@ export function recoverCoreOp<T, E, R>(
       const recovered: InferOpOk<R> = yield* new SuspendInstruction(() =>
         Promise.resolve(handler(error)),
       );
-      const recoveredOp: Op<unknown, unknown, []> | undefined = yield* new SuspendInstruction(() =>
+      const recoveredOp: Op<any, any, [], any> | undefined = yield* new SuspendInstruction(() =>
         Promise.resolve(coerceToNullaryOp(recovered)),
       );
 
@@ -455,14 +488,14 @@ export function recoverCoreOp<T, E, R>(
       rebuild: (newInner) =>
         recoverCoreOp(
           // SAFETY: rebuild callbacks are only used with the `inner` op they declared in this hook
-          unsafeCoerce<Op<T, E, []>>(newInner),
+          unsafeCoerce<Op<T, E, [], M>>(newInner),
           predicate,
           handler,
         ),
       rebuildForTimeout: (newInner) =>
         recoverCoreOp(
           // SAFETY: timeout push-through widens only the error channel with TimeoutError.
-          unsafeCoerce<Op<T, E | TimeoutError, []>>(newInner),
+          unsafeCoerce<Op<T, E | TimeoutError, [], M>>(newInner),
           (error: E | TimeoutError) =>
             !TimeoutError.is(error) && conditionalPredicate(predicate, error),
           // SAFETY: TimeoutError is filtered before `handler`, so it still only receives `E`.
@@ -472,12 +505,12 @@ export function recoverCoreOp<T, E, R>(
   );
 }
 
-export interface FluentHandlers<T, E, A extends readonly unknown[]> {
-  withRetry: (policy?: RetryPolicy) => OpInterface<T, E, A, boolean>;
-  withTimeout: (timeoutMs: number) => OpInterface<T, E | TimeoutError, A, boolean>;
-  withSignal: (signal: AbortSignal) => OpInterface<T, E, A, boolean>;
-  withRelease: (release: ReleaseFn<T>) => OpInterface<T, E, A, boolean>;
-  on: (event: OpLifecycleHook, handler: LifecycleFn<T, E, A>) => OpInterface<T, E, A, boolean>;
+export interface FluentHandlers<T, E, A extends readonly unknown[], M, Yieldable extends boolean> {
+  withRetry: (policy?: RetryPolicy) => OpInterface<T, E, A, M, Yieldable>;
+  withTimeout: (timeoutMs: number) => OpInterface<T, E | TimeoutError, A, M, Yieldable>;
+  withSignal: (signal: AbortSignal) => OpInterface<T, E, A, M, Yieldable>;
+  withRelease: (release: ReleaseFn<T>) => OpInterface<T, E, A, M, Yieldable>;
+  on: (event: OpLifecycleHook, handler: LifecycleFn<T, E, A>) => OpInterface<T, E, A, M, Yieldable>;
 }
 
 /**
@@ -489,9 +522,9 @@ export interface FluentHandlers<T, E, A extends readonly unknown[]> {
  *
  * @warning This function is UNSAFE and should be used only when the type is known to be correct.
  */
-export function asOpInterface<T, E, A extends readonly unknown[], Yieldable extends boolean>(
-  op: Op<T, E, A>,
-): OpInterface<T, E, A, Yieldable> {
+export function asOpInterface<T, E, A extends readonly unknown[], M, Yieldable extends boolean>(
+  op: Op<T, E, A, M>,
+): OpInterface<T, E, A, M, Yieldable> {
   // SAFETY: Op<T, E, A> is the public branded intersection over OpInterface<T, E, A>.
   return unsafeCoerce(op);
 }
@@ -500,17 +533,18 @@ export function makeFluentOp<
   T,
   E,
   A extends readonly unknown[],
+  M = EmptyMeta,
   Yieldable extends boolean = A extends [] ? true : false,
 >(
-  invoke: (...args: A) => Op<T, E, []>,
-  makeHandlers: (self: OpInterface<T, E, A, Yieldable>) => FluentHandlers<T, E, A>,
-  makeIterable?: () => Op<T, E, []>,
+  invoke: (...args: A) => Op<T, E, [], M>,
+  makeHandlers: (self: OpInterface<T, E, A, M, Yieldable>) => FluentHandlers<T, E, A, M, Yieldable>,
+  makeIterable?: () => Op<T, E, [], M>,
   bound = false,
-): OpInterface<T, E, A, Yieldable> {
+): OpInterface<T, E, A, M, Yieldable> {
   // SAFETY: `invoke` already has runtime signature `(...args: A) => Op<T, E, []>`.
   // `Object.assign` only decorates that function object with fluent handlers, so this
   // cast restores the intended callable+methods intersection that TS cannot infer.
-  const self: OpInterface<T, E, A, Yieldable> = unsafeCoerce(
+  const self: OpInterface<T, E, A, M, Yieldable> = unsafeCoerce(
     Object.assign(invoke, {
       run: (...args: A) =>
         drive(invoke(...args), createRunContext(new AbortController().signal, args)),
@@ -533,7 +567,7 @@ export function makeFluentOp<
           (resolved) =>
             mapErrCoreOp(resolved, (error) => (TimeoutError.is(error) ? error : transform(error))),
         ),
-      flatMap: <U, E2>(bind: (value: T) => Op<U, E2, []>) =>
+      flatMap: <R extends Op<any, any, [], any>>(bind: (value: T) => R) =>
         liftOp(
           self,
           (resolved) => flatMapCoreOp(resolved, bind),
@@ -584,23 +618,25 @@ export function liftOp<
   TIn,
   EIn,
   A extends readonly unknown[],
+  MIn,
   TOut,
   EOut,
+  MOut,
   Yieldable extends boolean,
 >(
-  op: OpInterface<TIn, EIn, A, Yieldable>,
-  mapCore: (resolved: Op<TIn, EIn, []>) => Op<TOut, EOut, []>,
+  op: OpInterface<TIn, EIn, A, MIn, Yieldable>,
+  mapCore: (resolved: Op<TIn, EIn, [], MIn>) => Op<TOut, EOut, [], MOut>,
   mapCoreForTimeout: (
-    resolved: Op<TIn, EIn | TimeoutError, []>,
-  ) => Op<TOut, EOut | TimeoutError, []>,
-): OpInterface<TOut, EOut, A, Yieldable> {
-  return makeFluentOp<TOut, EOut, A, Yieldable>(
+    resolved: Op<TIn, EIn | TimeoutError, [], MIn>,
+  ) => Op<TOut, EOut | TimeoutError, [], MOut>,
+): OpInterface<TOut, EOut, A, MOut, Yieldable> {
+  return makeFluentOp<TOut, EOut, A, MOut, Yieldable>(
     (...args) => mapCore(op(...args)),
     (self) => ({
       withRetry: (policy) =>
         liftOp(asOpInterface(op.withRetry(policy)), mapCore, mapCoreForTimeout),
       withTimeout: (timeoutMs) =>
-        liftOp<TIn, EIn | TimeoutError, A, TOut, EOut | TimeoutError, Yieldable>(
+        liftOp<TIn, EIn | TimeoutError, A, MIn, TOut, EOut | TimeoutError, MOut, Yieldable>(
           asOpInterface(op.withTimeout(timeoutMs)),
           mapCoreForTimeout,
           mapCoreForTimeout,
@@ -614,19 +650,19 @@ export function liftOp<
       ? () =>
           mapCore(
             // SAFETY: `isIterableOp` proves `op` has the nullary iterator surface.
-            unsafeCoerce<Op<TIn, EIn, []>>(op)(),
+            unsafeCoerce<Op<TIn, EIn, [], MIn>>(op)(),
           )
       : undefined,
     coerceToNullaryOp(op) !== undefined,
   );
 }
 
-export function onExitOp<T, E, A extends readonly unknown[], Yieldable extends boolean>(
-  op: OpInterface<T, E, A, Yieldable>,
+export function onExitOp<T, E, A extends readonly unknown[], M, Yieldable extends boolean>(
+  op: OpInterface<T, E, A, M, Yieldable>,
   finalize: ExitFn<T, E, A>,
-): OpInterface<T, E, A, Yieldable> {
+): OpInterface<T, E, A, M, Yieldable> {
   const source = op;
-  return makeFluentOp<T, E, A, Yieldable>(
+  return makeFluentOp<T, E, A, M, Yieldable>(
     (...args) =>
       onExitCoreOp(source(...args), (ctx) =>
         finalize({
@@ -651,7 +687,7 @@ export function onExitOp<T, E, A extends readonly unknown[], Yieldable extends b
       ? () =>
           onExitCoreOp(
             // SAFETY: `isIterableOp` proves `source` has the nullary iterator surface.
-            unsafeCoerce<Op<T, E, []>>(source)(),
+            unsafeCoerce<Op<T, E, [], M>>(source)(),
             // SAFETY: nullary iterator composition has no runtime args, so the finalize arity is compatible.
             unsafeCoerce(finalize),
           )
@@ -660,12 +696,12 @@ export function onExitOp<T, E, A extends readonly unknown[], Yieldable extends b
   );
 }
 
-export function onEnterOp<T, E, A extends readonly unknown[], Yieldable extends boolean>(
-  op: OpInterface<T, E, A, Yieldable>,
+export function onEnterOp<T, E, A extends readonly unknown[], M, Yieldable extends boolean>(
+  op: OpInterface<T, E, A, M, Yieldable>,
   initialize: EnterFn<A>,
-): OpInterface<T, E, A, Yieldable> {
+): OpInterface<T, E, A, M, Yieldable> {
   const source = op;
-  return makeFluentOp<T, E, A, Yieldable>(
+  return makeFluentOp<T, E, A, M, Yieldable>(
     (...args) => onEnterCoreOp(source(...args), ({ signal }) => initialize({ signal, args })),
     (self) => ({
       withRetry: (policy) => onEnterOp(asOpInterface(source.withRetry(policy)), initialize),
@@ -679,7 +715,7 @@ export function onEnterOp<T, E, A extends readonly unknown[], Yieldable extends 
       ? () =>
           onEnterCoreOp(
             // SAFETY: `isIterableOp` proves `source` has the nullary iterator surface.
-            unsafeCoerce<Op<T, E, []>>(source)(),
+            unsafeCoerce<Op<T, E, [], M>>(source)(),
             // SAFETY: nullary iterator composition has no runtime args, so the initialize arity is compatible.
             unsafeCoerce(initialize),
           )
@@ -688,11 +724,11 @@ export function onEnterOp<T, E, A extends readonly unknown[], Yieldable extends 
   );
 }
 
-export function onOp<T, E, A extends readonly unknown[], Yieldable extends boolean>(
-  op: OpInterface<T, E, A, Yieldable>,
+export function onOp<T, E, A extends readonly unknown[], M, Yieldable extends boolean>(
+  op: OpInterface<T, E, A, M, Yieldable>,
   event: OpLifecycleHook,
   handler: LifecycleFn<T, E, A>,
-): OpInterface<T, E, A, Yieldable> {
+): OpInterface<T, E, A, M, Yieldable> {
   const dispatch = event === "enter" ? onEnterOp : event === "exit" ? onExitOp : undefined;
 
   if (dispatch === undefined) {
@@ -706,12 +742,12 @@ export function onOp<T, E, A extends readonly unknown[], Yieldable extends boole
   );
 }
 
-export function withReleaseOp<T, E, A extends readonly unknown[], Yieldable extends boolean>(
-  op: OpInterface<T, E, A, Yieldable>,
+export function withReleaseOp<T, E, A extends readonly unknown[], M, Yieldable extends boolean>(
+  op: OpInterface<T, E, A, M, Yieldable>,
   release: ReleaseFn<T>,
-): OpInterface<T, E, A, Yieldable> {
+): OpInterface<T, E, A, M, Yieldable> {
   const source = op;
-  return makeFluentOp<T, E, A, Yieldable>(
+  return makeFluentOp<T, E, A, M, Yieldable>(
     (...args) => withCleanupCoreOp(source(...args), release),
     (self) => ({
       withRetry: (policy) => withReleaseOp(asOpInterface(source.withRetry(policy)), release),
@@ -725,7 +761,7 @@ export function withReleaseOp<T, E, A extends readonly unknown[], Yieldable exte
       ? () =>
           withCleanupCoreOp(
             // SAFETY: `isIterableOp` proves `source` has the nullary iterator surface.
-            unsafeCoerce<Op<T, E, []>>(source)(),
+            unsafeCoerce<Op<T, E, [], M>>(source)(),
             release,
           )
       : undefined,

--- a/packages/op/src/core/instructions.ts
+++ b/packages/op/src/core/instructions.ts
@@ -14,7 +14,7 @@ export class SuspendInstruction extends Tagged("SuspendInstruction") {
   // SAFETY: TS doesn't know the type of the yielded value, so it's always `unknown`
   // we use a single `any` here to avoid casting at every call site
   // oxlint-disable-next-line typescript/no-explicit-any
-  *[Symbol.iterator](): Generator<Instruction<never>, any, unknown> {
+  *[Symbol.iterator](): Generator<Instruction<never, any>, any, unknown> {
     return yield this;
   }
 }

--- a/packages/op/src/core/run-op.ts
+++ b/packages/op/src/core/run-op.ts
@@ -3,6 +3,6 @@ import type { Result } from "../result.js";
 import { createRunContext, drive } from "./runtime.js";
 import type { Op } from "../index.js";
 
-export function runOp<T, E>(op: Op<T, E, []>): Promise<Result<T, E | UnhandledException>> {
+export function runOp<T, E, M>(op: Op<T, E, [], M>): Promise<Result<T, E | UnhandledException>> {
   return drive(op, createRunContext(new AbortController().signal));
 }

--- a/packages/op/src/core/runtime.ts
+++ b/packages/op/src/core/runtime.ts
@@ -6,6 +6,7 @@ import {
   SuspendInstruction,
 } from "./instructions.js";
 import {
+  CUSTOM_INSTRUCTION_META,
   type CustomInstruction,
   type ExitContext,
   type Instruction,
@@ -28,6 +29,7 @@ function isCustomInstruction(
   return (
     typeof value === "object" &&
     value !== null &&
+    CUSTOM_INSTRUCTION_META in value &&
     "resolve" in value &&
     typeof value.resolve === "function"
   );

--- a/packages/op/src/core/runtime.ts
+++ b/packages/op/src/core/runtime.ts
@@ -23,9 +23,7 @@ export function createRunContext(
   return { signal, args, extensions };
 }
 
-function isCustomInstruction(
-  value: unknown,
-): value is CustomInstruction<unknown, unknown, unknown> {
+function isCustomInstruction(value: unknown): value is CustomInstruction<unknown, unknown> {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -118,7 +116,7 @@ async function driveInternal<T, E, M>(
     iter: Iterator<Instruction<E, M>, T, unknown>,
   ) => iter.next(await awaitWithAbortInterrupt(instruction.suspend(context)));
   const resumeCustom = async (
-    instruction: CustomInstruction<unknown, unknown, unknown>,
+    instruction: CustomInstruction<unknown, unknown>,
     iter: Iterator<Instruction<E, M>, T, unknown>,
   ) => iter.next(await awaitWithAbortInterrupt(Promise.resolve(instruction.resolve(context))));
   const registerExitFinalizer = (

--- a/packages/op/src/core/runtime.ts
+++ b/packages/op/src/core/runtime.ts
@@ -5,15 +5,32 @@ import {
   RegisterExitFinalizerInstruction,
   SuspendInstruction,
 } from "./instructions.js";
-import { type ExitContext, type Instruction, type RunContext } from "./types.js";
+import {
+  type CustomInstruction,
+  type ExitContext,
+  type Instruction,
+  type RunContext,
+} from "./types.js";
 import type { Op } from "../index.js";
 import { EMPTY_TUPLE } from "../shared.js";
 
 export function createRunContext(
   signal: AbortSignal,
   args: readonly unknown[] = EMPTY_TUPLE,
+  extensions: ReadonlyMap<unknown, unknown> = new Map(),
 ): RunContext<readonly unknown[]> {
-  return { signal, args };
+  return { signal, args, extensions };
+}
+
+function isCustomInstruction(
+  value: unknown,
+): value is CustomInstruction<unknown, unknown, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "resolve" in value &&
+    typeof value.resolve === "function"
+  );
 }
 
 export function closeGenerator(iterator: Iterator<unknown, unknown, unknown>) {
@@ -41,22 +58,22 @@ export function chainCleanupFaults(faults: readonly unknown[]): unknown {
   return chain;
 }
 
-export async function drive<T, E>(
-  op: Op<T, E, []>,
+export async function drive<T, E, M>(
+  op: Op<T, E, [], M>,
   context: RunContext<readonly unknown[]>,
 ): Promise<Result<T, E | UnhandledException>> {
   return driveInternal(op, context, false);
 }
 
-export async function driveInterruptOnAbort<T, E>(
-  op: Op<T, E, []>,
+export async function driveInterruptOnAbort<T, E, M>(
+  op: Op<T, E, [], M>,
   context: RunContext<readonly unknown[]>,
 ): Promise<Result<T, E | UnhandledException>> {
   return driveInternal(op, context, true);
 }
 
-async function driveInternal<T, E>(
-  op: Op<T, E, []>,
+async function driveInternal<T, E, M>(
+  op: Op<T, E, [], M>,
   context: RunContext<readonly unknown[]>,
   interruptOnAbort: boolean,
 ): Promise<Result<T, E | UnhandledException>> {
@@ -96,11 +113,15 @@ async function driveInternal<T, E>(
   };
   const resumeSuspended = async (
     instruction: SuspendInstruction,
-    iter: Iterator<Instruction<E>, T, unknown>,
+    iter: Iterator<Instruction<E, M>, T, unknown>,
   ) => iter.next(await awaitWithAbortInterrupt(instruction.suspend(context)));
+  const resumeCustom = async (
+    instruction: CustomInstruction<unknown, unknown, unknown>,
+    iter: Iterator<Instruction<E, M>, T, unknown>,
+  ) => iter.next(await awaitWithAbortInterrupt(Promise.resolve(instruction.resolve(context))));
   const registerExitFinalizer = (
     instruction: RegisterExitFinalizerInstruction,
-    iter: Iterator<Instruction<E>, T, unknown>,
+    iter: Iterator<Instruction<E, M>, T, unknown>,
   ) => {
     const argsAtRegistration = instruction.args ?? runArgs;
     finalizers.push((ctx) =>
@@ -137,7 +158,7 @@ async function driveInternal<T, E>(
   };
   const settleWithCleanup = async (
     result: Result<T, E | UnhandledException>,
-    iter?: Iterator<Instruction<unknown>, T, unknown>,
+    iter?: Iterator<Instruction<unknown, M>, T, unknown>,
   ): Promise<Result<T, E | UnhandledException>> => {
     if (iter !== undefined) {
       closeGenerator(iter);
@@ -163,6 +184,10 @@ async function driveInternal<T, E>(
         const instr = step.value;
         if (instr instanceof RegisterExitFinalizerInstruction) {
           step = registerExitFinalizer(instr, iter);
+          continue;
+        }
+        if (isCustomInstruction(instr)) {
+          step = await resumeCustom(instr, iter);
           continue;
         }
         if (isErrInstruction<E>(instr)) {

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -6,6 +6,7 @@ import type { RegisterExitFinalizerInstruction, SuspendInstruction } from "./ins
 import type { Op } from "../index.js";
 
 declare const EMPTY_META: unique symbol;
+export const NEEDS = Symbol("prodkit.op.needs");
 export const CUSTOM_INSTRUCTION_META = Symbol("prodkit.op.custom-instruction-meta");
 
 export type EmptyMeta = {
@@ -29,22 +30,58 @@ type WithoutEmptyMeta<M> = M extends EmptyMeta ? never : M;
 type MergeMetaRight<B> = [WithoutEmptyMeta<B>] extends [never] ? EmptyMeta : WithoutEmptyMeta<B>;
 type AllMetaKeys<U> = U extends unknown ? keyof U : never;
 
-type MergeMetaObjects<A, B> = NormalizeMeta<{
-  readonly [K in keyof StripEmpty<A> | keyof StripEmpty<B>]: K extends keyof StripEmpty<A> &
-    keyof StripEmpty<B>
+export type NeedsRecord = { readonly [k: string]: true };
+
+type ReadNeeds<M> = typeof NEEDS extends keyof StripEmpty<M>
+  ? StripEmpty<M>[typeof NEEDS] extends NeedsRecord
+    ? StripEmpty<M>[typeof NEEDS]
+    : {}
+  : {};
+
+type DropNeedsNamespace<R, NS extends string> = R extends NeedsRecord
+  ? { readonly [K in Exclude<keyof R, NS>]: true }
+  : {};
+
+type MergeNeedsRecords<A, B> = Simplify<
+  (A extends NeedsRecord ? A : {}) & (B extends NeedsRecord ? B : {})
+>;
+
+type NeedsRecordFromMeta<U> = U extends { readonly [NEEDS]: infer R extends NeedsRecord }
+  ? R
+  : never;
+
+type MergeNeedsUnion<U> = {
+  readonly [K in NeedsRecordFromMeta<U> extends NeedsRecord
+    ? keyof NeedsRecordFromMeta<U>
+    : never]: true;
+};
+
+type MergeMetaValue<A, B, K extends PropertyKey> = K extends typeof NEEDS
+  ? MergeNeedsRecords<
+      K extends keyof StripEmpty<A> ? ReadNeeds<A> : {},
+      K extends keyof StripEmpty<B> ? ReadNeeds<B> : {}
+    >
+  : K extends keyof StripEmpty<A> & keyof StripEmpty<B>
     ? StripEmpty<A>[K] | StripEmpty<B>[K]
     : K extends keyof StripEmpty<A>
       ? StripEmpty<A>[K]
       : K extends keyof StripEmpty<B>
         ? StripEmpty<B>[K]
         : never;
+
+type MergeMetaObjects<A, B> = NormalizeMeta<{
+  readonly [K in keyof StripEmpty<A> | keyof StripEmpty<B>]: MergeMetaValue<A, B, K>;
 }>;
 
 type MergeUnionMeta<U> = NormalizeMeta<
   [U] extends [never]
     ? EmptyMeta
     : {
-        readonly [K in AllMetaKeys<U>]: U extends Record<K, infer V> ? V : never;
+        readonly [K in AllMetaKeys<U>]: K extends typeof NEEDS
+          ? DeepIdentity<MergeNeedsUnion<U>>
+          : U extends Record<K, infer V>
+            ? V
+            : never;
       }
 >;
 
@@ -70,6 +107,44 @@ export type InferOpOk<R> = R extends Op<infer T, any, [], any> ? T : Awaited<R>;
 export type InferOpErr<R> = R extends Op<any, infer E, [], any> ? E : never;
 
 export type InferOpMeta<R> = R extends Op<any, any, infer _A, infer M> ? M : EmptyMeta;
+
+export type SetNeedsNamespace<M, NS extends string> = NormalizeMeta<
+  Simplify<
+    Omit<StripEmpty<M>, typeof NEEDS> & {
+      readonly [NEEDS]: Simplify<ReadNeeds<M> & { readonly [K in NS]: true }>;
+    }
+  >
+>;
+
+export type ClearNeedsNamespace<M, NS extends string> =
+  DropNeedsNamespace<ReadNeeds<M>, NS> extends infer Remaining
+    ? [keyof Remaining] extends [never]
+      ? NormalizeMeta<Omit<StripEmpty<M>, typeof NEEDS>>
+      : NormalizeMeta<Simplify<Omit<StripEmpty<M>, typeof NEEDS> & { readonly [NEEDS]: Remaining }>>
+    : never;
+
+export type NeedsLatchMeta<M = EmptyMeta, NS extends string = never> = NS extends never
+  ? never
+  : SetNeedsNamespace<M, NS>;
+
+/**
+ * Whether top-level {@link BaseOp.run} is available from operation metadata.
+ *
+ * Operations are runnable by default. Extension packages mark blocked operations
+ * with namespaced entries under the internal needs latch or the public `Needs(...)`
+ * wrapper.
+ */
+export type IsRunnable<M> =
+  IsAny<M> extends true ? true : [HasNeeds<M>] extends [true] ? false : true;
+
+type HasNeeds<M> =
+  NeedsRecordFromMeta<StripEmpty<M>> extends infer R
+    ? [R] extends [never]
+      ? false
+      : [keyof R & string] extends [never]
+        ? false
+        : true
+    : false;
 
 /**
  * Extension protocol for custom generator yield instructions.
@@ -164,11 +239,20 @@ export interface BaseOp<T, E, A extends readonly unknown[], M = EmptyMeta> {
    * @example
    * const result = await Op.of(1).run();
    */
-  run(...args: A): Promise<Result<T, E | UnhandledException>>;
+  run: [IsRunnable<M>] extends [false]
+    ? never
+    : (...args: A) => Promise<Result<T, E | UnhandledException>>;
 }
 
-export type Identity<T> =
-  T extends Record<PropertyKey, unknown> ? { [K in keyof T]: T[K] } & {} : T;
+type ObjectNotFunction<T> = T extends object
+  ? T extends (...args: never[]) => unknown
+    ? never
+    : T
+  : never;
+
+export type Identity<T> = T extends ObjectNotFunction<T> ? { [K in keyof T]: T[K] } & {} : T;
+export type DeepIdentity<T> =
+  T extends ObjectNotFunction<T> ? { [K in keyof T]: DeepIdentity<T[K]> } & {} : T;
 export type RequireOne<T> = {
   [K in keyof T]: Identity<Required<Pick<T, K>> & Partial<Omit<T, K>>>;
 }[keyof T];

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -85,14 +85,14 @@ export type RequireOne<T> = {
   [K in keyof T]: Identity<Required<Pick<T, K>> & Partial<Omit<T, K>>>;
 }[keyof T];
 
-export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends boolean> {
+export interface FluentOp<T, E, A extends readonly unknown[]> {
   /**
    * Wraps the operation in retry policy logic.
    *
    * @example
    * const resilient = Op.try(() => fetch("/ping")).withRetry();
    */
-  withRetry(policy?: RequireOne<RetryPolicy>): Op<T, E, A, Yieldable>;
+  withRetry(policy?: RequireOne<RetryPolicy>): Op<T, E, A>;
 
   /**
    * Applies a timeout budget in milliseconds to the wrapped operation.
@@ -100,7 +100,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const bounded = Op.try(() => fetch("/slow")).withTimeout(1000);
    */
-  withTimeout(timeoutMs: number): Op<T, E | TimeoutError, A, Yieldable>;
+  withTimeout(timeoutMs: number): Op<T, E | TimeoutError, A>;
 
   /**
    * Binds an external abort signal to the wrapped operation run.
@@ -108,7 +108,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const linked = Op.of(1).withSignal(new AbortController().signal);
    */
-  withSignal(signal: AbortSignal): Op<T, E, A, Yieldable>;
+  withSignal(signal: AbortSignal): Op<T, E, A>;
 
   /**
    * Registers release logic that runs after a successful value is produced.
@@ -116,7 +116,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const managed = Op.of({ close() {} }).withRelease((r) => r.close());
    */
-  withRelease(release: ReleaseFn<T>): Op<T, E, A, Yieldable>;
+  withRelease(release: ReleaseFn<T>): Op<T, E, A>;
 
   /**
    * Register a handler that runs before the operation body starts.
@@ -124,14 +124,14 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const withEnter = Op.of(1).on("enter", () => console.log("start"));
    */
-  on(event: "enter", initialize: EnterFn<A>): Op<T, E, A, Yieldable>;
+  on(event: "enter", initialize: EnterFn<A>): Op<T, E, A>;
   /**
    * Register a handler that runs after the operation settles.
    *
    * @example
    * const withExit = Op.of(1).on("exit", () => console.log("done"));
    */
-  on(event: "exit", finalize: ExitFn<T, E, A>): Op<T, E, A, Yieldable>;
+  on(event: "exit", finalize: ExitFn<T, E, A>): Op<T, E, A>;
 
   /**
    * Transforms the success value while preserving args and error channel.
@@ -139,7 +139,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const mapped = Op.of(2).map((n) => n * 2);
    */
-  map<U>(transform: (value: T) => U): Op<Awaited<U>, E, A, Yieldable>;
+  map<U>(transform: (value: T) => U): Op<Awaited<U>, E, A>;
 
   /**
    * Transforms the tracked typed error channel while preserving success values.
@@ -147,7 +147,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const mappedError = Op.fail("x" as const).mapErr((e) => ({ code: e }));
    */
-  mapErr<E2>(transform: (error: TrackedErr<E>) => E2): Op<T, E2, A, Yieldable>;
+  mapErr<E2>(transform: (error: TrackedErr<E>) => E2): Op<T, E2, A>;
 
   /**
    * Binds the success value into the next operation.
@@ -155,7 +155,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const chained = Op.of(1).flatMap((n) => Op.of(n + 1));
    */
-  flatMap<U, E2>(bind: (value: T) => Op<U, E2, []>): Op<U, E | E2, A, Yieldable>;
+  flatMap<U, E2>(bind: (value: T) => Op<U, E2, []>): Op<U, E | E2, A>;
 
   /**
    * Observes successful values without changing the success payload.
@@ -163,7 +163,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const observed = Op.of(1).tap((n) => console.log(n));
    */
-  tap<R>(observe: (value: T) => R): Op<T, E | InferOpErr<R>, A, Yieldable>;
+  tap<R>(observe: (value: T) => R): Op<T, E | InferOpErr<R>, A>;
 
   /**
    * Observes tracked errors without changing the original success payload.
@@ -171,9 +171,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
    * @example
    * const observedError = Op.fail("x" as const).tapErr((e) => console.error(e));
    */
-  tapErr<R>(
-    observe: (error: TrackedErr<E>) => R,
-  ): Op<T, TrackedErr<E> | InferOpErr<R>, A, Yieldable>;
+  tapErr<R>(observe: (error: TrackedErr<E>) => R): Op<T, TrackedErr<E> | InferOpErr<R>, A>;
 
   /**
    * Recovers selected typed failures into a fallback value or operation.
@@ -184,7 +182,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
   recover<ECaught extends TrackedErr<E>, R>(
     predicate: (error: TrackedErr<E>) => error is ECaught,
     handler: (error: ECaught) => R,
-  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A, Yieldable>;
+  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A>;
   /**
    * Recovers typed failures selected by a tagged predicate method.
    *
@@ -197,7 +195,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
   recover<ECaught extends TrackedErr<E>, R>(
     predicate: WithPredicateMethod<TrackedErr<ECaught>>,
     handler: (error: ECaught) => R,
-  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A, Yieldable>;
+  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A>;
   /**
    * Recovers failures selected by a boolean predicate over the error value.
    *
@@ -207,7 +205,7 @@ export interface FluentOp<T, E, A extends readonly unknown[], Yieldable extends 
   recover<R>(
     predicate: (error: TrackedErr<E>) => boolean,
     handler: (error: TrackedErr<E>) => R,
-  ): Op<T | InferOpOk<R>, TrackedErr<E> | InferOpErr<R>, A, Yieldable>;
+  ): Op<T | InferOpOk<R>, TrackedErr<E> | InferOpErr<R>, A>;
 }
 
 export interface OpIterable<T, E> {
@@ -219,9 +217,7 @@ export type OpInterface<
   E,
   A extends readonly unknown[],
   Yieldable extends boolean = A extends [] ? true : false,
-> = BaseOp<T, E, A> &
-  FluentOp<T, E, A, Yieldable> &
-  (Yieldable extends true ? OpIterable<T, E> : {});
+> = BaseOp<T, E, A> & FluentOp<T, E, A> & (Yieldable extends true ? OpIterable<T, E> : {});
 
 export interface OpHooks<T, E, TInner = unknown, EInner = unknown> {
   /** Inner op to push policy wrappers to (when present with `rebuild`). */

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -6,82 +6,45 @@ import type { RegisterExitFinalizerInstruction, SuspendInstruction } from "./ins
 import type { Op } from "../index.js";
 
 declare const EMPTY_META: unique symbol;
-export const NEEDS = Symbol("prodkit.op.needs");
+declare const BLOCKING: unique symbol;
 export const CUSTOM_INSTRUCTION_META = Symbol("prodkit.op.custom-instruction-meta");
 
-export type EmptyMeta = {
-  readonly [EMPTY_META]: true;
-};
+type MergeBlockingValue<VA, VB> =
+  VA extends Blocking<infer TA>
+    ? VB extends Blocking<infer TB>
+      ? Blocking<TA | TB>
+      : Blocking<TA>
+    : VB extends Blocking<infer TB>
+      ? Blocking<TB>
+      : VA | VB;
 
-type IsAny<T> = 0 extends 1 & T ? true : false;
-export type NormalizeMeta<M> = [M] extends [never]
-  ? EmptyMeta
-  : M extends EmptyMeta
-    ? EmptyMeta
-    : M extends object
-      ? keyof M extends never
-        ? EmptyMeta
-        : M
-      : M;
-
-export type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
-export type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
-type WithoutEmptyMeta<M> = M extends EmptyMeta ? never : M;
-type MergeMetaRight<B> = [WithoutEmptyMeta<B>] extends [never] ? EmptyMeta : WithoutEmptyMeta<B>;
-type AllMetaKeys<U> = U extends unknown ? keyof U : never;
-
-export type NeedsRecord = { readonly [k: string]: true };
-
-type ReadNeeds<M> = typeof NEEDS extends keyof StripEmpty<M>
-  ? StripEmpty<M>[typeof NEEDS] extends NeedsRecord
-    ? StripEmpty<M>[typeof NEEDS]
-    : {}
-  : {};
-
-type DropNeedsNamespace<R, NS extends string> = R extends NeedsRecord
-  ? { readonly [K in Exclude<keyof R, NS>]: true }
-  : {};
-
-type MergeNeedsRecords<A, B> = Simplify<
-  (A extends NeedsRecord ? A : {}) & (B extends NeedsRecord ? B : {})
->;
-
-type NeedsRecordFromMeta<U> = U extends { readonly [NEEDS]: infer R extends NeedsRecord }
-  ? R
-  : never;
-
-type MergeNeedsUnion<U> = {
-  readonly [K in NeedsRecordFromMeta<U> extends NeedsRecord
-    ? keyof NeedsRecordFromMeta<U>
-    : never]: true;
-};
-
-type MergeMetaValue<A, B, K extends PropertyKey> = K extends typeof NEEDS
-  ? MergeNeedsRecords<
-      K extends keyof StripEmpty<A> ? ReadNeeds<A> : {},
-      K extends keyof StripEmpty<B> ? ReadNeeds<B> : {}
-    >
-  : K extends keyof StripEmpty<A> & keyof StripEmpty<B>
-    ? StripEmpty<A>[K] | StripEmpty<B>[K]
-    : K extends keyof StripEmpty<A>
-      ? StripEmpty<A>[K]
-      : K extends keyof StripEmpty<B>
-        ? StripEmpty<B>[K]
-        : never;
+type MergeMetaValue<A, B, K extends PropertyKey> = K extends keyof StripEmpty<A> &
+  keyof StripEmpty<B>
+  ? MergeBlockingValue<StripEmpty<A>[K], StripEmpty<B>[K]>
+  : K extends keyof StripEmpty<A>
+    ? StripEmpty<A>[K]
+    : K extends keyof StripEmpty<B>
+      ? StripEmpty<B>[K]
+      : never;
 
 type MergeMetaObjects<A, B> = NormalizeMeta<{
   readonly [K in keyof StripEmpty<A> | keyof StripEmpty<B>]: MergeMetaValue<A, B, K>;
 }>;
 
+type UnionMetaValueAt<U, K extends PropertyKey> = U extends Record<K, infer V> ? V : never;
+
+type CollectBlockingPayload<U, K extends PropertyKey> =
+  U extends Record<K, Blocking<infer R>> ? R : never;
+
+type MergeUnionMetaValue<U, K extends PropertyKey> = [CollectBlockingPayload<U, K>] extends [never]
+  ? UnionMetaValueAt<U, K>
+  : Blocking<CollectBlockingPayload<U, K>>;
+
 type MergeUnionMeta<U> = NormalizeMeta<
   [U] extends [never]
     ? EmptyMeta
     : {
-        readonly [K in AllMetaKeys<U>]: K extends typeof NEEDS
-          ? DeepIdentity<MergeNeedsUnion<U>>
-          : U extends Record<K, infer V>
-            ? V
-            : never;
+        readonly [K in AllMetaKeys<U>]: MergeUnionMetaValue<U, K>;
       }
 >;
 
@@ -108,43 +71,54 @@ export type InferOpErr<R> = R extends Op<any, infer E, [], any> ? E : never;
 
 export type InferOpMeta<R> = R extends Op<any, any, infer _A, infer M> ? M : EmptyMeta;
 
-export type SetNeedsNamespace<M, NS extends string> = NormalizeMeta<
-  Simplify<
-    Omit<StripEmpty<M>, typeof NEEDS> & {
-      readonly [NEEDS]: Simplify<ReadNeeds<M> & { readonly [K in NS]: true }>;
-    }
-  >
+export type SetBlockingMeta<M, K extends PropertyKey, T> = NormalizeMeta<
+  Simplify<StripEmpty<M> & { readonly [P in K]: Blocking<T> }>
 >;
-
-export type ClearNeedsNamespace<M, NS extends string> =
-  DropNeedsNamespace<ReadNeeds<M>, NS> extends infer Remaining
-    ? [keyof Remaining] extends [never]
-      ? NormalizeMeta<Omit<StripEmpty<M>, typeof NEEDS>>
-      : NormalizeMeta<Simplify<Omit<StripEmpty<M>, typeof NEEDS> & { readonly [NEEDS]: Remaining }>>
-    : never;
-
-export type NeedsLatchMeta<M = EmptyMeta, NS extends string = never> = NS extends never
-  ? never
-  : SetNeedsNamespace<M, NS>;
 
 /**
  * Whether top-level {@link BaseOp.run} is available from operation metadata.
  *
- * Operations are runnable by default. Extension packages mark blocked operations
- * with namespaced entries under the internal needs latch or the public `Needs(...)`
- * wrapper.
+ * Operations are runnable by default. Extension packages block `.run()` by placing
+ * a {@link Blocking} value on a metadata key, or by wrapping with `withBlocking(...)`.
  */
 export type IsRunnable<M> =
-  IsAny<M> extends true ? true : [HasNeeds<M>] extends [true] ? false : true;
+  IsAny<M> extends true ? true : [HasBlocking<M>] extends [true] ? false : true;
 
-type HasNeeds<M> =
-  NeedsRecordFromMeta<StripEmpty<M>> extends infer R
-    ? [R] extends [never]
-      ? false
-      : [keyof R & string] extends [never]
-        ? false
-        : true
+type HasBlocking<M> = keyof StripEmpty<M> extends never
+  ? false
+  : {
+        [K in keyof StripEmpty<M>]: StripEmpty<M>[K] extends Blocking<infer R>
+          ? [R] extends [never]
+            ? false
+            : true
+          : false;
+      }[keyof StripEmpty<M>] extends true
+    ? true
     : false;
+
+export type EmptyMeta = {
+  readonly [EMPTY_META]: true;
+};
+
+/** Branded metadata value that blocks top-level `.run()` until its payload is satisfied. */
+export type Blocking<T> = { readonly [BLOCKING]: T };
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+export type NormalizeMeta<M> = [M] extends [never]
+  ? EmptyMeta
+  : M extends EmptyMeta
+    ? EmptyMeta
+    : M extends object
+      ? keyof M extends never
+        ? EmptyMeta
+        : M
+      : M;
+
+export type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
+export type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
+type WithoutEmptyMeta<M> = M extends EmptyMeta ? never : M;
+type MergeMetaRight<B> = [WithoutEmptyMeta<B>] extends [never] ? EmptyMeta : WithoutEmptyMeta<B>;
+type AllMetaKeys<U> = U extends unknown ? keyof U : never;
 
 /**
  * Extension protocol for custom generator yield instructions.

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -23,7 +23,8 @@ export type NormalizeMeta<M> = [M] extends [never]
         : M
       : M;
 
-type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
+export type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
+export type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
 type WithoutEmptyMeta<M> = M extends EmptyMeta ? never : M;
 type MergeMetaRight<B> = [WithoutEmptyMeta<B>] extends [never] ? EmptyMeta : WithoutEmptyMeta<B>;
 type AllMetaKeys<U> = U extends unknown ? keyof U : never;

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -12,14 +12,7 @@ export type EmptyMeta = {
   readonly [EMPTY_META]: true;
 };
 
-type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
-type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
 type IsAny<T> = 0 extends 1 & T ? true : false;
-type UnionToIntersection<U> = (U extends unknown ? (value: U) => void : never) extends (
-  value: infer I,
-) => void
-  ? I
-  : never;
 export type NormalizeMeta<M> = [M] extends [never]
   ? EmptyMeta
   : M extends EmptyMeta
@@ -30,14 +23,28 @@ export type NormalizeMeta<M> = [M] extends [never]
         : M
       : M;
 
-export type InferMetaReqs<M> = M extends { readonly requirements: infer R } ? R : never;
+type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
+type WithoutEmptyMeta<M> = M extends EmptyMeta ? never : M;
+type MergeMetaRight<B> = [WithoutEmptyMeta<B>] extends [never] ? EmptyMeta : WithoutEmptyMeta<B>;
+type AllMetaKeys<U> = U extends unknown ? keyof U : never;
 
-type MergeMetaObjects<A, B, R = InferMetaReqs<A> | InferMetaReqs<B>> = NormalizeMeta<
-  Simplify<
-    Omit<StripEmpty<A> & {}, "requirements"> &
-      Omit<StripEmpty<B> & {}, "requirements"> &
-      ([R] extends [never] ? {} : { readonly requirements: R })
-  >
+type MergeMetaObjects<A, B> = NormalizeMeta<{
+  readonly [K in keyof StripEmpty<A> | keyof StripEmpty<B>]: K extends keyof StripEmpty<A> &
+    keyof StripEmpty<B>
+    ? StripEmpty<A>[K] | StripEmpty<B>[K]
+    : K extends keyof StripEmpty<A>
+      ? StripEmpty<A>[K]
+      : K extends keyof StripEmpty<B>
+        ? StripEmpty<B>[K]
+        : never;
+}>;
+
+type MergeUnionMeta<U> = NormalizeMeta<
+  [U] extends [never]
+    ? EmptyMeta
+    : {
+        readonly [K in AllMetaKeys<U>]: U extends Record<K, infer V> ? V : never;
+      }
 >;
 
 export type MergeMeta<A, B> =
@@ -49,7 +56,7 @@ export type MergeMeta<A, B> =
         ? NormalizeMeta<B>
         : [B] extends [EmptyMeta]
           ? NormalizeMeta<A>
-          : MergeMetaObjects<A, B>;
+          : MergeMetaObjects<A, MergeMetaRight<B>>;
 
 export type TrackedErr<E, Excluded = never> = E extends UnhandledException
   ? never
@@ -61,7 +68,7 @@ export type InferOpOk<R> = R extends Op<infer T, any, [], any> ? T : Awaited<R>;
 
 export type InferOpErr<R> = R extends Op<any, infer E, [], any> ? E : never;
 
-export type InferOpMeta<R> = R extends Op<any, any, readonly unknown[], infer M> ? M : EmptyMeta;
+export type InferOpMeta<R> = R extends Op<any, any, infer _A, infer M> ? M : EmptyMeta;
 
 export interface CustomInstruction<T, _E = never, M = EmptyMeta> {
   readonly [CUSTOM_INSTRUCTION_META]: M;
@@ -73,16 +80,9 @@ type ExtractInstructionMeta<Y> = Y extends CustomInstruction<any, any, infer M> 
 
 type NonEmptyInstructionMeta<Y> = Exclude<ExtractInstructionMeta<Y>, EmptyMeta>;
 
-type MergeInstructionMetaUnion<M, R = InferMetaReqs<M>> = NormalizeMeta<
-  Simplify<
-    Omit<StripEmpty<UnionToIntersection<M>> & {}, "requirements"> &
-      ([R] extends [never] ? {} : { readonly requirements: R })
-  >
->;
-
 export type InferInstructionMeta<Y> = [NonEmptyInstructionMeta<Y>] extends [never]
   ? EmptyMeta
-  : MergeInstructionMetaUnion<NonEmptyInstructionMeta<Y>>;
+  : MergeUnionMeta<NonEmptyInstructionMeta<Y>>;
 
 type DropUnknown<E> = unknown extends E ? never : E;
 type ExtractInstructionErr<Y> =

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -70,13 +70,23 @@ export type InferOpErr<R> = R extends Op<any, infer E, [], any> ? E : never;
 
 export type InferOpMeta<R> = R extends Op<any, any, infer _A, infer M> ? M : EmptyMeta;
 
-export interface CustomInstruction<T, _E = never, M = EmptyMeta> {
+/**
+ * Extension protocol for custom generator yield instructions.
+ *
+ * Implementations are detected at runtime via {@link CUSTOM_INSTRUCTION_META}
+ * and executed through {@link CustomInstruction.resolve}.
+ *
+ * Typed failures should be surfaced by yielding {@link Err} values from
+ * `[Symbol.iterator]` or from the enclosing generator; throws from `resolve`
+ * surface as {@link UnhandledException}.
+ */
+export interface CustomInstruction<T, M = EmptyMeta> {
   readonly [CUSTOM_INSTRUCTION_META]: M;
   resolve(context: RunContext<readonly unknown[]>): T | PromiseLike<T>;
   [Symbol.iterator](): Generator<this, T, unknown>;
 }
 
-type ExtractInstructionMeta<Y> = Y extends CustomInstruction<any, any, infer M> ? M : never;
+type ExtractInstructionMeta<Y> = Y extends CustomInstruction<any, infer M> ? M : never;
 
 type NonEmptyInstructionMeta<Y> = Exclude<ExtractInstructionMeta<Y>, EmptyMeta>;
 
@@ -85,11 +95,9 @@ export type InferInstructionMeta<Y> = [NonEmptyInstructionMeta<Y>] extends [neve
   : MergeUnionMeta<NonEmptyInstructionMeta<Y>>;
 
 type DropUnknown<E> = unknown extends E ? never : E;
-type ExtractInstructionErr<Y> =
-  Y extends CustomInstruction<any, infer E, any> ? DropUnknown<E> : never;
 type ExtractResultErr<Y> = Y extends Err<unknown, infer E> ? DropUnknown<E> : never;
 
-export type InferInstructionErr<Y> = ExtractResultErr<Y> | ExtractInstructionErr<Y>;
+export type InferInstructionErr<Y> = ExtractResultErr<Y>;
 
 /**
  * Passed to {@link ExitFn} when the run unwinds.
@@ -133,7 +141,7 @@ export type Instruction<E, M = EmptyMeta> =
   | Err<unknown, E>
   | SuspendInstruction
   | RegisterExitFinalizerInstruction
-  | CustomInstruction<unknown, E, M>;
+  | CustomInstruction<unknown, M>;
 
 export type ReleaseFn<T> = (value: T) => unknown;
 

--- a/packages/op/src/core/types.ts
+++ b/packages/op/src/core/types.ts
@@ -1,8 +1,55 @@
+// oxlint-disable typescript/no-explicit-any
 import type { TimeoutError, UnhandledException } from "../errors.js";
 import type { Err, Result } from "../result.js";
 import type { RetryPolicy } from "../policies.js";
 import type { RegisterExitFinalizerInstruction, SuspendInstruction } from "./instructions.js";
 import type { Op } from "../index.js";
+
+declare const EMPTY_META: unique symbol;
+export const CUSTOM_INSTRUCTION_META = Symbol("prodkit.op.custom-instruction-meta");
+
+export type EmptyMeta = {
+  readonly [EMPTY_META]: true;
+};
+
+type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
+type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type UnionToIntersection<U> = (U extends unknown ? (value: U) => void : never) extends (
+  value: infer I,
+) => void
+  ? I
+  : never;
+export type NormalizeMeta<M> = [M] extends [never]
+  ? EmptyMeta
+  : M extends EmptyMeta
+    ? EmptyMeta
+    : M extends object
+      ? keyof M extends never
+        ? EmptyMeta
+        : M
+      : M;
+
+export type InferMetaReqs<M> = M extends { readonly requirements: infer R } ? R : never;
+
+type MergeMetaObjects<A, B, R = InferMetaReqs<A> | InferMetaReqs<B>> = NormalizeMeta<
+  Simplify<
+    Omit<StripEmpty<A> & {}, "requirements"> &
+      Omit<StripEmpty<B> & {}, "requirements"> &
+      ([R] extends [never] ? {} : { readonly requirements: R })
+  >
+>;
+
+export type MergeMeta<A, B> =
+  IsAny<A> extends true
+    ? any
+    : IsAny<B> extends true
+      ? any
+      : [A] extends [EmptyMeta]
+        ? NormalizeMeta<B>
+        : [B] extends [EmptyMeta]
+          ? NormalizeMeta<A>
+          : MergeMetaObjects<A, B>;
 
 export type TrackedErr<E, Excluded = never> = E extends UnhandledException
   ? never
@@ -10,9 +57,39 @@ export type TrackedErr<E, Excluded = never> = E extends UnhandledException
     ? never
     : E;
 
-export type InferOpOk<R> = R extends Op<infer T, unknown, []> ? T : Awaited<R>;
+export type InferOpOk<R> = R extends Op<infer T, any, [], any> ? T : Awaited<R>;
 
-export type InferOpErr<R> = R extends Op<unknown, infer E, []> ? E : never;
+export type InferOpErr<R> = R extends Op<any, infer E, [], any> ? E : never;
+
+export type InferOpMeta<R> = R extends Op<any, any, readonly unknown[], infer M> ? M : EmptyMeta;
+
+export interface CustomInstruction<T, _E = never, M = EmptyMeta> {
+  readonly [CUSTOM_INSTRUCTION_META]: M;
+  resolve(context: RunContext<readonly unknown[]>): T | PromiseLike<T>;
+  [Symbol.iterator](): Generator<this, T, unknown>;
+}
+
+type ExtractInstructionMeta<Y> = Y extends CustomInstruction<any, any, infer M> ? M : never;
+
+type NonEmptyInstructionMeta<Y> = Exclude<ExtractInstructionMeta<Y>, EmptyMeta>;
+
+type MergeInstructionMetaUnion<M, R = InferMetaReqs<M>> = NormalizeMeta<
+  Simplify<
+    Omit<StripEmpty<UnionToIntersection<M>> & {}, "requirements"> &
+      ([R] extends [never] ? {} : { readonly requirements: R })
+  >
+>;
+
+export type InferInstructionMeta<Y> = [NonEmptyInstructionMeta<Y>] extends [never]
+  ? EmptyMeta
+  : MergeInstructionMetaUnion<NonEmptyInstructionMeta<Y>>;
+
+type DropUnknown<E> = unknown extends E ? never : E;
+type ExtractInstructionErr<Y> =
+  Y extends CustomInstruction<any, infer E, any> ? DropUnknown<E> : never;
+type ExtractResultErr<Y> = Y extends Err<unknown, infer E> ? DropUnknown<E> : never;
+
+export type InferInstructionErr<Y> = ExtractResultErr<Y> | ExtractInstructionErr<Y>;
 
 /**
  * Passed to {@link ExitFn} when the run unwinds.
@@ -38,6 +115,7 @@ export interface EnterContext<A extends readonly unknown[] = []> {
 export interface RunContext<A extends readonly unknown[] = readonly unknown[]> {
   readonly signal: AbortSignal;
   readonly args: A;
+  readonly extensions: ReadonlyMap<unknown, unknown>;
 }
 
 export type EnterFn<A extends readonly unknown[] = []> = (ctx: EnterContext<A>) => unknown;
@@ -51,10 +129,11 @@ export type LifecycleFn<T = unknown, E = unknown, A extends readonly unknown[] =
 /** Widened hook for {@link builders.defer} where enclosing `Op` `T`/`E` are not inferred. */
 export type AnyExitFn = ExitFn<unknown, unknown, readonly unknown[]>;
 
-export type Instruction<E> =
+export type Instruction<E, M = EmptyMeta> =
   | Err<unknown, E>
   | SuspendInstruction
-  | RegisterExitFinalizerInstruction;
+  | RegisterExitFinalizerInstruction
+  | CustomInstruction<unknown, E, M>;
 
 export type ReleaseFn<T> = (value: T) => unknown;
 
@@ -63,12 +142,12 @@ export type OpLifecycleHook = "enter" | "exit";
 
 export type WithPredicateMethod<E> = { is: (value: unknown) => value is E };
 
-export interface BaseOp<T, E, A extends readonly unknown[]> {
+export interface BaseOp<T, E, A extends readonly unknown[], M = EmptyMeta> {
   /** Type discriminant for an `Op` instance. */
   readonly _tag: "Op";
 
   /** Provides the operation with runtime arguments. */
-  (...args: A): Op<T, E, []>;
+  (...args: A): Op<T, E, [], M>;
 
   /**
    * Executes the operation with runtime arguments and returns a `Result`.
@@ -85,14 +164,14 @@ export type RequireOne<T> = {
   [K in keyof T]: Identity<Required<Pick<T, K>> & Partial<Omit<T, K>>>;
 }[keyof T];
 
-export interface FluentOp<T, E, A extends readonly unknown[]> {
+export interface FluentOp<T, E, A extends readonly unknown[], M = EmptyMeta> {
   /**
    * Wraps the operation in retry policy logic.
    *
    * @example
    * const resilient = Op.try(() => fetch("/ping")).withRetry();
    */
-  withRetry(policy?: RequireOne<RetryPolicy>): Op<T, E, A>;
+  withRetry(policy?: RequireOne<RetryPolicy>): Op<T, E, A, M>;
 
   /**
    * Applies a timeout budget in milliseconds to the wrapped operation.
@@ -100,7 +179,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const bounded = Op.try(() => fetch("/slow")).withTimeout(1000);
    */
-  withTimeout(timeoutMs: number): Op<T, E | TimeoutError, A>;
+  withTimeout(timeoutMs: number): Op<T, E | TimeoutError, A, M>;
 
   /**
    * Binds an external abort signal to the wrapped operation run.
@@ -108,7 +187,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const linked = Op.of(1).withSignal(new AbortController().signal);
    */
-  withSignal(signal: AbortSignal): Op<T, E, A>;
+  withSignal(signal: AbortSignal): Op<T, E, A, M>;
 
   /**
    * Registers release logic that runs after a successful value is produced.
@@ -116,7 +195,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const managed = Op.of({ close() {} }).withRelease((r) => r.close());
    */
-  withRelease(release: ReleaseFn<T>): Op<T, E, A>;
+  withRelease(release: ReleaseFn<T>): Op<T, E, A, M>;
 
   /**
    * Register a handler that runs before the operation body starts.
@@ -124,14 +203,14 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const withEnter = Op.of(1).on("enter", () => console.log("start"));
    */
-  on(event: "enter", initialize: EnterFn<A>): Op<T, E, A>;
+  on(event: "enter", initialize: EnterFn<A>): Op<T, E, A, M>;
   /**
    * Register a handler that runs after the operation settles.
    *
    * @example
    * const withExit = Op.of(1).on("exit", () => console.log("done"));
    */
-  on(event: "exit", finalize: ExitFn<T, E, A>): Op<T, E, A>;
+  on(event: "exit", finalize: ExitFn<T, E, A>): Op<T, E, A, M>;
 
   /**
    * Transforms the success value while preserving args and error channel.
@@ -139,7 +218,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const mapped = Op.of(2).map((n) => n * 2);
    */
-  map<U>(transform: (value: T) => U): Op<Awaited<U>, E, A>;
+  map<U>(transform: (value: T) => U): Op<Awaited<U>, E, A, M>;
 
   /**
    * Transforms the tracked typed error channel while preserving success values.
@@ -147,7 +226,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const mappedError = Op.fail("x" as const).mapErr((e) => ({ code: e }));
    */
-  mapErr<E2>(transform: (error: TrackedErr<E>) => E2): Op<T, E2, A>;
+  mapErr<E2>(transform: (error: TrackedErr<E>) => E2): Op<T, E2, A, M>;
 
   /**
    * Binds the success value into the next operation.
@@ -155,7 +234,9 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const chained = Op.of(1).flatMap((n) => Op.of(n + 1));
    */
-  flatMap<U, E2>(bind: (value: T) => Op<U, E2, []>): Op<U, E | E2, A>;
+  flatMap<R extends Op<any, any, [], any>>(
+    bind: (value: T) => R,
+  ): Op<InferOpOk<R>, E | InferOpErr<R>, A, MergeMeta<M, InferOpMeta<R>>>;
 
   /**
    * Observes successful values without changing the success payload.
@@ -163,7 +244,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const observed = Op.of(1).tap((n) => console.log(n));
    */
-  tap<R>(observe: (value: T) => R): Op<T, E | InferOpErr<R>, A>;
+  tap<R>(observe: (value: T) => R): Op<T, E | InferOpErr<R>, A, MergeMeta<M, InferOpMeta<R>>>;
 
   /**
    * Observes tracked errors without changing the original success payload.
@@ -171,7 +252,9 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
    * @example
    * const observedError = Op.fail("x" as const).tapErr((e) => console.error(e));
    */
-  tapErr<R>(observe: (error: TrackedErr<E>) => R): Op<T, TrackedErr<E> | InferOpErr<R>, A>;
+  tapErr<R>(
+    observe: (error: TrackedErr<E>) => R,
+  ): Op<T, TrackedErr<E> | InferOpErr<R>, A, MergeMeta<M, InferOpMeta<R>>>;
 
   /**
    * Recovers selected typed failures into a fallback value or operation.
@@ -182,7 +265,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
   recover<ECaught extends TrackedErr<E>, R>(
     predicate: (error: TrackedErr<E>) => error is ECaught,
     handler: (error: ECaught) => R,
-  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A>;
+  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A, MergeMeta<M, InferOpMeta<R>>>;
   /**
    * Recovers typed failures selected by a tagged predicate method.
    *
@@ -195,7 +278,7 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
   recover<ECaught extends TrackedErr<E>, R>(
     predicate: WithPredicateMethod<TrackedErr<ECaught>>,
     handler: (error: ECaught) => R,
-  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A>;
+  ): Op<T | InferOpOk<R>, TrackedErr<E, ECaught> | InferOpErr<R>, A, MergeMeta<M, InferOpMeta<R>>>;
   /**
    * Recovers failures selected by a boolean predicate over the error value.
    *
@@ -205,32 +288,33 @@ export interface FluentOp<T, E, A extends readonly unknown[]> {
   recover<R>(
     predicate: (error: TrackedErr<E>) => boolean,
     handler: (error: TrackedErr<E>) => R,
-  ): Op<T | InferOpOk<R>, TrackedErr<E> | InferOpErr<R>, A>;
+  ): Op<T | InferOpOk<R>, TrackedErr<E> | InferOpErr<R>, A, MergeMeta<M, InferOpMeta<R>>>;
 }
 
-export interface OpIterable<T, E> {
-  [Symbol.iterator](): Generator<Instruction<E>, T, unknown>;
+export interface OpIterable<T, E, M = EmptyMeta> {
+  [Symbol.iterator](): Generator<Instruction<E, M>, T, unknown>;
 }
 
 export type OpInterface<
   T,
   E,
   A extends readonly unknown[],
+  M = EmptyMeta,
   Yieldable extends boolean = A extends [] ? true : false,
-> = BaseOp<T, E, A> & FluentOp<T, E, A> & (Yieldable extends true ? OpIterable<T, E> : {});
+> = BaseOp<T, E, A, M> & FluentOp<T, E, A, M> & (Yieldable extends true ? OpIterable<T, E, M> : {});
 
-export interface OpHooks<T, E, TInner = unknown, EInner = unknown> {
+export interface OpHooks<T, E, M = EmptyMeta, TInner = unknown, EInner = unknown> {
   /** Inner op to push policy wrappers to (when present with `rebuild`). */
-  inner?: Op<TInner, EInner, []>;
+  inner?: Op<TInner, EInner, [], any>;
   /** Rebuild this operator around a new inner op for push-through policy behavior. */
-  rebuild?: (newInner: Op<TInner, EInner, []>) => Op<T, E, []>;
+  rebuild?: (newInner: Op<TInner, EInner, [], any>) => Op<T, E, [], M>;
   /** Optional timeout-specific rebuild for error-channel widening edge cases. */
   rebuildForTimeout?: (
-    newInner: Op<TInner, EInner | TimeoutError, []>,
-  ) => Op<T, E | TimeoutError, []>;
-  withRelease: (release: ReleaseFn<T>) => Op<T, E, []>;
+    newInner: Op<TInner, EInner | TimeoutError, [], any>,
+  ) => Op<T, E | TimeoutError, [], M>;
+  withRelease: (release: ReleaseFn<T>) => Op<T, E, [], M>;
   /** Backs public `.on("enter", fn)` on ops built from these hooks. */
-  registerEnterInitialize: (initialize: EnterFn<[]>) => Op<T, E, []>;
+  registerEnterInitialize: (initialize: EnterFn<[]>) => Op<T, E, [], M>;
   /** Backs public `.on("exit", fn)` on ops built from these hooks. */
-  registerExitFinalize: (finalize: ExitFn<T, E, []>) => Op<T, E, []>;
+  registerExitFinalize: (finalize: ExitFn<T, E, []>) => Op<T, E, [], M>;
 }

--- a/packages/op/src/index.ts
+++ b/packages/op/src/index.ts
@@ -2,6 +2,7 @@ import { defer, fail, fromGenFn, sleep, succeed, _try } from "./builders.js";
 import { allOp, allSettledOp, anyOp, raceOp, settleOp } from "./combinators.js";
 import { ErrorGroup, TimeoutError, type UnhandledException } from "./errors.js";
 import {
+  type Blocking,
   type EmptyMeta,
   type EnterContext,
   type ExitContext,
@@ -15,7 +16,7 @@ import {
 } from "./core/types.js";
 import { runOp } from "./core/run-op.js";
 import { exponentialBackoff } from "./policies.js";
-import { Needs, type NeedsOp } from "./needs.js";
+import { withBlocking, type BlockingOp } from "./blocking.js";
 import { Tagged } from "./tagged.js";
 import { type Result } from "./result.js";
 
@@ -180,6 +181,7 @@ export type Op<T, E, A extends readonly unknown[], M = EmptyMeta> = OpInterface<
   Tagged<"Op">;
 
 export type {
+  Blocking,
   EmptyMeta,
   CustomInstruction,
   EnterContext,
@@ -189,7 +191,7 @@ export type {
   MergeMeta,
   OpLifecycleHook,
 };
-export { Needs, type NeedsOp };
+export { withBlocking, type BlockingOp };
 export type { BackoffOptions, RetryPolicy } from "./policies.js";
 
 export { TimeoutError, ErrorGroup, exponentialBackoff };

--- a/packages/op/src/index.ts
+++ b/packages/op/src/index.ts
@@ -2,8 +2,13 @@ import { defer, fail, fromGenFn, sleep, succeed, _try } from "./builders.js";
 import { allOp, allSettledOp, anyOp, raceOp, settleOp } from "./combinators.js";
 import { ErrorGroup, TimeoutError, type UnhandledException } from "./errors.js";
 import {
+  type EmptyMeta,
   type EnterContext,
   type ExitContext,
+  type CustomInstruction,
+  type InferInstructionMeta,
+  type InferOpMeta,
+  type MergeMeta,
   type OpLifecycleHook,
   OpInterface,
 } from "./core/types.js";
@@ -44,8 +49,8 @@ export const Op = Object.assign(fromGenFn, {
    * @example
    * const value = await Op.run(Op.of(1));
    */
-  run: <T, E, A extends readonly unknown[]>(
-    op: Op<T, E, A>,
+  run: <T, E, A extends readonly unknown[], M>(
+    op: Op<T, E, A, M>,
     ...args: A
   ): Promise<Result<T, E | UnhandledException>> => {
     return runOp(op(...args));
@@ -169,9 +174,19 @@ export const Op = Object.assign(fromGenFn, {
   empty,
 });
 
-export type Op<T, E, A extends readonly unknown[]> = OpInterface<T, E, A> & Tagged<"Op">;
+export type Op<T, E, A extends readonly unknown[], M = EmptyMeta> = OpInterface<T, E, A, M> &
+  Tagged<"Op">;
 
-export type { EnterContext, ExitContext, OpLifecycleHook };
+export type {
+  EmptyMeta,
+  CustomInstruction,
+  EnterContext,
+  ExitContext,
+  InferInstructionMeta,
+  InferOpMeta,
+  MergeMeta,
+  OpLifecycleHook,
+};
 export type { BackoffOptions, RetryPolicy } from "./policies.js";
 
 export { TimeoutError, ErrorGroup, exponentialBackoff };

--- a/packages/op/src/index.ts
+++ b/packages/op/src/index.ts
@@ -169,12 +169,7 @@ export const Op = Object.assign(fromGenFn, {
   empty,
 });
 
-export type Op<
-  T,
-  E,
-  A extends readonly unknown[],
-  Yieldable extends boolean = A extends [] ? true : false,
-> = OpInterface<T, E, A, Yieldable> & Tagged<"Op">;
+export type Op<T, E, A extends readonly unknown[]> = OpInterface<T, E, A> & Tagged<"Op">;
 
 export type { EnterContext, ExitContext, OpLifecycleHook };
 export type { BackoffOptions, RetryPolicy } from "./policies.js";

--- a/packages/op/src/index.ts
+++ b/packages/op/src/index.ts
@@ -8,12 +8,14 @@ import {
   type CustomInstruction,
   type InferInstructionMeta,
   type InferOpMeta,
+  type IsRunnable,
   type MergeMeta,
   type OpLifecycleHook,
   OpInterface,
 } from "./core/types.js";
 import { runOp } from "./core/run-op.js";
 import { exponentialBackoff } from "./policies.js";
+import { Needs, type NeedsOp } from "./needs.js";
 import { Tagged } from "./tagged.js";
 import { type Result } from "./result.js";
 
@@ -50,7 +52,7 @@ export const Op = Object.assign(fromGenFn, {
    * const value = await Op.run(Op.of(1));
    */
   run: <T, E, A extends readonly unknown[], M>(
-    op: Op<T, E, A, M>,
+    op: [IsRunnable<M>] extends [false] ? never : Op<T, E, A, M>,
     ...args: A
   ): Promise<Result<T, E | UnhandledException>> => {
     return runOp(op(...args));
@@ -187,6 +189,7 @@ export type {
   MergeMeta,
   OpLifecycleHook,
 };
+export { Needs, type NeedsOp };
 export type { BackoffOptions, RetryPolicy } from "./policies.js";
 
 export { TimeoutError, ErrorGroup, exponentialBackoff };

--- a/packages/op/src/internal.ts
+++ b/packages/op/src/internal.ts
@@ -20,14 +20,21 @@ export {
   sleepWithSignal,
   type AbortSignalLike,
   unsafeCoerce,
+  hasOwn,
 } from "./shared.js";
 export { SuspendInstruction } from "./core/instructions.js";
 export { createRunContext, drive } from "./core/runtime.js";
-export { CUSTOM_INSTRUCTION_META } from "./core/types.js";
+export { CUSTOM_INSTRUCTION_META, NEEDS } from "./core/types.js";
 export type {
+  ClearNeedsNamespace,
   CustomInstruction,
+  IsRunnable,
+  NeedsLatchMeta,
+  NeedsRecord,
   NormalizeMeta,
   RunContext,
+  SetNeedsNamespace,
   Simplify,
   StripEmpty,
 } from "./core/types.js";
+export { Needs, type NeedsOp } from "./needs.js";

--- a/packages/op/src/internal.ts
+++ b/packages/op/src/internal.ts
@@ -21,3 +21,7 @@ export {
   type AbortSignalLike,
   unsafeCoerce,
 } from "./shared.js";
+export { SuspendInstruction } from "./core/instructions.js";
+export { createRunContext, drive } from "./core/runtime.js";
+export { CUSTOM_INSTRUCTION_META } from "./core/types.js";
+export type { CustomInstruction, RunContext } from "./core/types.js";

--- a/packages/op/src/internal.ts
+++ b/packages/op/src/internal.ts
@@ -24,17 +24,15 @@ export {
 } from "./shared.js";
 export { SuspendInstruction } from "./core/instructions.js";
 export { createRunContext, drive } from "./core/runtime.js";
-export { CUSTOM_INSTRUCTION_META, NEEDS } from "./core/types.js";
+export { CUSTOM_INSTRUCTION_META } from "./core/types.js";
 export type {
-  ClearNeedsNamespace,
+  Blocking,
   CustomInstruction,
   IsRunnable,
-  NeedsLatchMeta,
-  NeedsRecord,
   NormalizeMeta,
   RunContext,
-  SetNeedsNamespace,
+  SetBlockingMeta,
   Simplify,
   StripEmpty,
 } from "./core/types.js";
-export { Needs, type NeedsOp } from "./needs.js";
+export { withBlocking, type BlockingOp } from "./blocking.js";

--- a/packages/op/src/internal.ts
+++ b/packages/op/src/internal.ts
@@ -24,4 +24,10 @@ export {
 export { SuspendInstruction } from "./core/instructions.js";
 export { createRunContext, drive } from "./core/runtime.js";
 export { CUSTOM_INSTRUCTION_META } from "./core/types.js";
-export type { CustomInstruction, RunContext } from "./core/types.js";
+export type {
+  CustomInstruction,
+  NormalizeMeta,
+  RunContext,
+  Simplify,
+  StripEmpty,
+} from "./core/types.js";

--- a/packages/op/src/metadata.types.test.ts
+++ b/packages/op/src/metadata.types.test.ts
@@ -14,7 +14,7 @@ type LoggerReq = { readonly requirements: "logger" };
 type CacheReq = { readonly requirements: "cache" };
 type SpanReq = { readonly spans: "auth" };
 
-class TestInstruction<T, M> implements CustomInstruction<T, never, M> {
+class TestInstruction<T, M> implements CustomInstruction<T, M> {
   readonly [CUSTOM_INSTRUCTION_META]: M = undefined as M;
   private readonly value: T;
 

--- a/packages/op/src/metadata.types.test.ts
+++ b/packages/op/src/metadata.types.test.ts
@@ -1,22 +1,20 @@
 import { describe, expectTypeOf, test } from "vitest";
 import {
-  Needs,
+  withBlocking,
   Op,
   type EmptyMeta,
   type InferInstructionMeta,
   type InferOpMeta,
   type MergeMeta,
-  type NeedsOp,
+  type Blocking,
+  type BlockingOp,
 } from "./index.js";
 import {
   CUSTOM_INSTRUCTION_META,
-  NEEDS,
-  type ClearNeedsNamespace,
   type CustomInstruction,
   type IsRunnable,
-  type NeedsLatchMeta,
+  type NormalizeMeta,
   type RunContext,
-  type SetNeedsNamespace,
 } from "./internal.js";
 import type { IsEqual, Assert } from "./type-test-utils.js";
 import type { Result } from "./result.js";
@@ -26,9 +24,9 @@ type DatabaseReq = { readonly requirements: "database" };
 type LoggerReq = { readonly requirements: "logger" };
 type CacheReq = { readonly requirements: "cache" };
 type SpanReq = { readonly spans: "auth" };
-type DiNeeds = NeedsLatchMeta<EmptyMeta, "di">;
-type AuthNeeds = NeedsLatchMeta<EmptyMeta, "auth">;
-type DiAndAuthNeeds = SetNeedsNamespace<SetNeedsNamespace<EmptyMeta, "di">, "auth">;
+type DiMeta = { readonly requirements: Blocking<"database"> };
+type AuthMeta = { readonly auth: Blocking<true> };
+type DiAndAuthMeta = MergeMeta<DiMeta, AuthMeta>;
 
 class TestInstruction<T, M> implements CustomInstruction<T, M> {
   readonly [CUSTOM_INSTRUCTION_META]: M = undefined as M;
@@ -102,9 +100,18 @@ describe("metadata type contracts", () => {
     >;
   });
 
-  test("needs metadata merges by namespace instead of unioning records", () => {
-    type _ = Assert<IsEqual<MergeMeta<DiNeeds, AuthNeeds>, DiAndAuthNeeds>>;
-    type _StillBlocked = Assert<IsEqual<IsRunnable<DiAndAuthNeeds>, false>>;
+  test("blocking metadata merges payloads at shared keys", () => {
+    type _ = Assert<
+      IsEqual<
+        MergeMeta<
+          { readonly requirements: Blocking<"database"> },
+          { readonly requirements: Blocking<"logger"> }
+        >,
+        { readonly requirements: Blocking<"database" | "logger"> }
+      >
+    >;
+    type _CrossKey = Assert<IsEqual<MergeMeta<DiMeta, AuthMeta>, DiAndAuthMeta>>;
+    type _StillBlocked = Assert<IsEqual<IsRunnable<DiAndAuthMeta>, false>>;
   });
 
   test("combinators preserve or merge metadata", () => {
@@ -156,7 +163,7 @@ describe("metadata type contracts", () => {
   });
 });
 
-describe("Needs type contracts", () => {
+describe("Blocking type contracts", () => {
   test("plain ops are runnable by default", () => {
     const op = Op(function* () {
       return yield* new TestInstruction<number, SpanReq>(1);
@@ -168,49 +175,45 @@ describe("Needs type contracts", () => {
     type _ = Assert<IsEqual<IsRunnable<InferOpMeta<typeof op>>, true>>;
   });
 
-  test("Needs blocks .run() for a namespace until that namespace is cleared", () => {
+  test("Blocking blocks .run() until the metadata payload is satisfied", () => {
     const ready = Op(function* () {
       return 1;
     });
-    const blocked = Needs(ready, "demo");
+    const blocked = withBlocking(ready, "demo");
 
     type _Blocked = Assert<IsEqual<IsRunnable<InferOpMeta<typeof blocked>>, false>>;
-    type _Needs = Assert<
-      IsEqual<InferOpMeta<typeof blocked>, { readonly [NEEDS]: { readonly demo: true } }>
+    type _Blocking = Assert<
+      IsEqual<InferOpMeta<typeof blocked>, { readonly demo: Blocking<true> }>
     >;
-    type _NeedsOp = Assert<IsEqual<typeof blocked, NeedsOp<number, never, [], EmptyMeta, "demo">>>;
+    type _BlockingOp = Assert<
+      IsEqual<typeof blocked, BlockingOp<number, never, [], EmptyMeta, "demo", true>>
+    >;
 
-    // @ts-expect-error - wrapped in Needs
+    // @ts-expect-error - wrapped in Blocking
     blocked.run();
     expectTypeOf(ready.run()).toMatchTypeOf<Promise<unknown>>();
   });
 
-  test("internal needs latch blocks run without Needs wrapper", () => {
+  test("Blocking metadata blocks run without the Blocking wrapper", () => {
     const blocked = Op(function* () {
-      return yield* new TestInstruction<number, DiNeeds>(1);
+      return yield* new TestInstruction<number, DiMeta>(1);
     });
 
     type _ = Assert<IsEqual<IsRunnable<InferOpMeta<typeof blocked>>, false>>;
 
-    // @ts-expect-error - needs latch present
+    // @ts-expect-error - blocking metadata present
     blocked.run();
   });
 
-  test("clearing one namespace keeps other namespaces blocked", () => {
-    type _ClearedDi = Assert<
-      IsEqual<
-        ClearNeedsNamespace<DiAndAuthNeeds, "di">,
-        { readonly [NEEDS]: { readonly auth: true } }
-      >
-    >;
-    type _StillBlocked = Assert<
-      IsEqual<IsRunnable<ClearNeedsNamespace<DiAndAuthNeeds, "di">>, false>
-    >;
+  test("satisfying one blocking key keeps other blocking keys blocked", () => {
+    type ClearedAuth = Omit<DiAndAuthMeta, "requirements">;
+    type _ClearedAuth = Assert<IsEqual<ClearedAuth, { readonly auth: Blocking<true> }>>;
+    type _StillBlocked = Assert<IsEqual<IsRunnable<ClearedAuth>, false>>;
     type _FullyCleared = Assert<
-      IsEqual<ClearNeedsNamespace<DiAndAuthNeeds, "di" | "auth">, EmptyMeta>
+      IsEqual<NormalizeMeta<Omit<DiAndAuthMeta, "requirements" | "auth">>, EmptyMeta>
     >;
     type _Runnable = Assert<
-      IsEqual<IsRunnable<ClearNeedsNamespace<DiAndAuthNeeds, "di" | "auth">>, true>
+      IsEqual<IsRunnable<NormalizeMeta<Omit<DiAndAuthMeta, "requirements" | "auth">>>, true>
     >;
   });
 });

--- a/packages/op/src/metadata.types.test.ts
+++ b/packages/op/src/metadata.types.test.ts
@@ -1,18 +1,34 @@
 import { describe, expectTypeOf, test } from "vitest";
 import {
+  Needs,
   Op,
   type EmptyMeta,
   type InferInstructionMeta,
   type InferOpMeta,
   type MergeMeta,
+  type NeedsOp,
 } from "./index.js";
-import { CUSTOM_INSTRUCTION_META, type CustomInstruction, type RunContext } from "./core/types.js";
+import {
+  CUSTOM_INSTRUCTION_META,
+  NEEDS,
+  type ClearNeedsNamespace,
+  type CustomInstruction,
+  type IsRunnable,
+  type NeedsLatchMeta,
+  type RunContext,
+  type SetNeedsNamespace,
+} from "./internal.js";
 import type { IsEqual, Assert } from "./type-test-utils.js";
+import type { Result } from "./result.js";
+import type { UnhandledException } from "./errors.js";
 
 type DatabaseReq = { readonly requirements: "database" };
 type LoggerReq = { readonly requirements: "logger" };
 type CacheReq = { readonly requirements: "cache" };
 type SpanReq = { readonly spans: "auth" };
+type DiNeeds = NeedsLatchMeta<EmptyMeta, "di">;
+type AuthNeeds = NeedsLatchMeta<EmptyMeta, "auth">;
+type DiAndAuthNeeds = SetNeedsNamespace<SetNeedsNamespace<EmptyMeta, "di">, "auth">;
 
 class TestInstruction<T, M> implements CustomInstruction<T, M> {
   readonly [CUSTOM_INSTRUCTION_META]: M = undefined as M;
@@ -86,6 +102,11 @@ describe("metadata type contracts", () => {
     >;
   });
 
+  test("needs metadata merges by namespace instead of unioning records", () => {
+    type _ = Assert<IsEqual<MergeMeta<DiNeeds, AuthNeeds>, DiAndAuthNeeds>>;
+    type _StillBlocked = Assert<IsEqual<IsRunnable<DiAndAuthNeeds>, false>>;
+  });
+
   test("combinators preserve or merge metadata", () => {
     const source = Op(function* () {
       return yield* new TestInstruction<number, DatabaseReq>(1);
@@ -131,6 +152,65 @@ describe("metadata type contracts", () => {
 
     type _ = Assert<
       IsEqual<MergeMeta<DatabaseReq, CacheReq>, { readonly requirements: "database" | "cache" }>
+    >;
+  });
+});
+
+describe("Needs type contracts", () => {
+  test("plain ops are runnable by default", () => {
+    const op = Op(function* () {
+      return yield* new TestInstruction<number, SpanReq>(1);
+    });
+
+    const result = op.run();
+
+    expectTypeOf(result).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
+    type _ = Assert<IsEqual<IsRunnable<InferOpMeta<typeof op>>, true>>;
+  });
+
+  test("Needs blocks .run() for a namespace until that namespace is cleared", () => {
+    const ready = Op(function* () {
+      return 1;
+    });
+    const blocked = Needs(ready, "demo");
+
+    type _Blocked = Assert<IsEqual<IsRunnable<InferOpMeta<typeof blocked>>, false>>;
+    type _Needs = Assert<
+      IsEqual<InferOpMeta<typeof blocked>, { readonly [NEEDS]: { readonly demo: true } }>
+    >;
+    type _NeedsOp = Assert<IsEqual<typeof blocked, NeedsOp<number, never, [], EmptyMeta, "demo">>>;
+
+    // @ts-expect-error - wrapped in Needs
+    blocked.run();
+    expectTypeOf(ready.run()).toMatchTypeOf<Promise<unknown>>();
+  });
+
+  test("internal needs latch blocks run without Needs wrapper", () => {
+    const blocked = Op(function* () {
+      return yield* new TestInstruction<number, DiNeeds>(1);
+    });
+
+    type _ = Assert<IsEqual<IsRunnable<InferOpMeta<typeof blocked>>, false>>;
+
+    // @ts-expect-error - needs latch present
+    blocked.run();
+  });
+
+  test("clearing one namespace keeps other namespaces blocked", () => {
+    type _ClearedDi = Assert<
+      IsEqual<
+        ClearNeedsNamespace<DiAndAuthNeeds, "di">,
+        { readonly [NEEDS]: { readonly auth: true } }
+      >
+    >;
+    type _StillBlocked = Assert<
+      IsEqual<IsRunnable<ClearNeedsNamespace<DiAndAuthNeeds, "di">>, false>
+    >;
+    type _FullyCleared = Assert<
+      IsEqual<ClearNeedsNamespace<DiAndAuthNeeds, "di" | "auth">, EmptyMeta>
+    >;
+    type _Runnable = Assert<
+      IsEqual<IsRunnable<ClearNeedsNamespace<DiAndAuthNeeds, "di" | "auth">>, true>
     >;
   });
 });

--- a/packages/op/src/metadata.types.test.ts
+++ b/packages/op/src/metadata.types.test.ts
@@ -12,6 +12,7 @@ import type { IsEqual, Assert } from "./type-test-utils.js";
 type DatabaseReq = { readonly requirements: "database" };
 type LoggerReq = { readonly requirements: "logger" };
 type CacheReq = { readonly requirements: "cache" };
+type SpanReq = { readonly spans: "auth" };
 
 class TestInstruction<T, M> implements CustomInstruction<T, never, M> {
   readonly [CUSTOM_INSTRUCTION_META]: M = undefined as M;
@@ -40,6 +41,14 @@ describe("metadata type contracts", () => {
     type _ = Assert<IsEqual<InferOpMeta<typeof op>, EmptyMeta>>;
   });
 
+  test("custom instructions contribute metadata on arity ops", () => {
+    const op = Op(function* (_id: string) {
+      return yield* new TestInstruction<number, DatabaseReq>(1);
+    });
+
+    type _ = Assert<IsEqual<InferOpMeta<typeof op>, DatabaseReq>>;
+  });
+
   test("custom instructions contribute metadata", () => {
     const op = Op(function* () {
       return yield* new TestInstruction<number, DatabaseReq>(1);
@@ -62,13 +71,19 @@ describe("metadata type contracts", () => {
     type _ = Assert<IsEqual<InferOpMeta<typeof outer>, DatabaseReq>>;
   });
 
-  test("merge metadata unions requirements", () => {
+  test("merge metadata unions values at shared keys", () => {
     type _ = Assert<
       IsEqual<MergeMeta<DatabaseReq, LoggerReq>, { readonly requirements: "database" | "logger" }>
     >;
     type _EmptyLeft = Assert<IsEqual<MergeMeta<EmptyMeta, DatabaseReq>, DatabaseReq>>;
     type _EmptyRight = Assert<IsEqual<MergeMeta<DatabaseReq, EmptyMeta>, DatabaseReq>>;
     type _EmptyBoth = Assert<IsEqual<MergeMeta<EmptyMeta, EmptyMeta>, EmptyMeta>>;
+    type _CrossKey = Assert<
+      IsEqual<
+        MergeMeta<DatabaseReq, SpanReq>,
+        { readonly requirements: "database"; readonly spans: "auth" }
+      >
+    >;
   });
 
   test("combinators preserve or merge metadata", () => {

--- a/packages/op/src/metadata.types.test.ts
+++ b/packages/op/src/metadata.types.test.ts
@@ -1,0 +1,121 @@
+import { describe, expectTypeOf, test } from "vitest";
+import {
+  Op,
+  type EmptyMeta,
+  type InferInstructionMeta,
+  type InferOpMeta,
+  type MergeMeta,
+} from "./index.js";
+import { CUSTOM_INSTRUCTION_META, type CustomInstruction, type RunContext } from "./core/types.js";
+import type { IsEqual, Assert } from "./type-test-utils.js";
+
+type DatabaseReq = { readonly requirements: "database" };
+type LoggerReq = { readonly requirements: "logger" };
+type CacheReq = { readonly requirements: "cache" };
+
+class TestInstruction<T, M> implements CustomInstruction<T, never, M> {
+  readonly [CUSTOM_INSTRUCTION_META]: M = undefined as M;
+  private readonly value: T;
+
+  constructor(value: T) {
+    this.value = value;
+  }
+
+  resolve(_context: RunContext): T {
+    return this.value;
+  }
+
+  *[Symbol.iterator](): Generator<this, T, unknown> {
+    return (yield this) as T;
+  }
+}
+
+describe("metadata type contracts", () => {
+  test("plain ops carry empty metadata", () => {
+    const op = Op(function* () {
+      return 1;
+    });
+
+    expectTypeOf(op.run()).toMatchTypeOf<Promise<unknown>>();
+    type _ = Assert<IsEqual<InferOpMeta<typeof op>, EmptyMeta>>;
+  });
+
+  test("custom instructions contribute metadata", () => {
+    const op = Op(function* () {
+      return yield* new TestInstruction<number, DatabaseReq>(1);
+    });
+
+    type _OpMeta = Assert<IsEqual<InferOpMeta<typeof op>, DatabaseReq>>;
+    type _ = Assert<
+      IsEqual<InferInstructionMeta<TestInstruction<number, DatabaseReq>>, DatabaseReq>
+    >;
+  });
+
+  test("nested yielded ops bubble metadata", () => {
+    const nested = Op(function* () {
+      return yield* new TestInstruction<number, DatabaseReq>(1);
+    });
+    const outer = Op(function* () {
+      return yield* nested;
+    });
+
+    type _ = Assert<IsEqual<InferOpMeta<typeof outer>, DatabaseReq>>;
+  });
+
+  test("merge metadata unions requirements", () => {
+    type _ = Assert<
+      IsEqual<MergeMeta<DatabaseReq, LoggerReq>, { readonly requirements: "database" | "logger" }>
+    >;
+    type _EmptyLeft = Assert<IsEqual<MergeMeta<EmptyMeta, DatabaseReq>, DatabaseReq>>;
+    type _EmptyRight = Assert<IsEqual<MergeMeta<DatabaseReq, EmptyMeta>, DatabaseReq>>;
+    type _EmptyBoth = Assert<IsEqual<MergeMeta<EmptyMeta, EmptyMeta>, EmptyMeta>>;
+  });
+
+  test("combinators preserve or merge metadata", () => {
+    const source = Op(function* () {
+      return yield* new TestInstruction<number, DatabaseReq>(1);
+    });
+    const observed = Op(function* () {
+      return yield* new TestInstruction<string, LoggerReq>("ok");
+    });
+    const recovered = Op.fail("bad" as const).recover(
+      (error): error is "bad" => error === "bad",
+      () => observed,
+    );
+
+    const mapped = source.map((value) => value + 1);
+    const mappedErr = source.mapErr((error) => error);
+    const retried = source.withRetry();
+    const timed = source.withTimeout(1);
+    const signaled = source.withSignal(new AbortController().signal);
+    const released = source.withRelease(() => {});
+    const entered = source.on("enter", () => {});
+    const exited = source.on("exit", () => {});
+    const flatMapped = source.flatMap(() => observed);
+    const tapped = source.tap(() => observed);
+    const tappedErr = source.tapErr(() => observed);
+
+    type _Mapped = Assert<IsEqual<InferOpMeta<typeof mapped>, DatabaseReq>>;
+    type _MappedErr = Assert<IsEqual<InferOpMeta<typeof mappedErr>, DatabaseReq>>;
+    type _Retried = Assert<IsEqual<InferOpMeta<typeof retried>, DatabaseReq>>;
+    type _Timed = Assert<IsEqual<InferOpMeta<typeof timed>, DatabaseReq>>;
+    type _Signaled = Assert<IsEqual<InferOpMeta<typeof signaled>, DatabaseReq>>;
+    type _Released = Assert<IsEqual<InferOpMeta<typeof released>, DatabaseReq>>;
+    type _Entered = Assert<IsEqual<InferOpMeta<typeof entered>, DatabaseReq>>;
+    type _Exited = Assert<IsEqual<InferOpMeta<typeof exited>, DatabaseReq>>;
+    type _FlatMapped = Assert<
+      IsEqual<InferOpMeta<typeof flatMapped>, { readonly requirements: "database" | "logger" }>
+    >;
+    type _Tapped = Assert<
+      IsEqual<InferOpMeta<typeof tapped>, { readonly requirements: "database" | "logger" }>
+    >;
+    type _TappedErr = Assert<
+      IsEqual<InferOpMeta<typeof tappedErr>, { readonly requirements: "database" | "logger" }>
+    >;
+    type _Recovered = Assert<IsEqual<InferOpMeta<typeof recovered>, LoggerReq>>;
+
+    type _ = Assert<
+      IsEqual<MergeMeta<DatabaseReq, CacheReq>, { readonly requirements: "database" | "cache" }>
+    >;
+  });
+});

--- a/packages/op/src/needs.ts
+++ b/packages/op/src/needs.ts
@@ -1,0 +1,26 @@
+import { unsafeCoerce } from "./shared.js";
+import { type EmptyMeta, type OpInterface, type SetNeedsNamespace } from "./core/types.js";
+import type { Tagged } from "./tagged.js";
+
+type OpType<T, E, A extends readonly unknown[], M> = OpInterface<T, E, A, M> & Tagged<"Op">;
+
+/** An operation that is not ready for top-level `.run()`. */
+export type NeedsOp<
+  T,
+  E,
+  A extends readonly unknown[],
+  M = EmptyMeta,
+  NS extends string = string,
+> = OpType<T, E, A, SetNeedsNamespace<M, NS>>;
+
+/**
+ * Marks an operation as needing extension-specific preconditions before
+ * top-level `.run()`.
+ */
+export function Needs<T, E, A extends readonly unknown[], M, const NS extends string>(
+  op: OpType<T, E, A, M>,
+  _namespace: NS,
+): NeedsOp<T, E, A, M, NS> {
+  // SAFETY: type-only metadata transition; runtime op behavior is unchanged.
+  return unsafeCoerce(op);
+}

--- a/packages/op/src/policies.ts
+++ b/packages/op/src/policies.ts
@@ -4,6 +4,7 @@ import { makeFluentOp, onOp, withCleanupCoreOp } from "./core/fluent.js";
 import {
   RequireOne,
   TrackedErr,
+  type EmptyMeta,
   type Instruction,
   type OpInterface,
   type RunContext,
@@ -82,11 +83,11 @@ export const DEFAULT_RETRY_POLICY = Object.freeze({
   getDelay: exponentialBackoff.DEFAULT,
 }) satisfies RetryPolicy;
 
-function makePolicyLiftedOp<T, E, A extends readonly unknown[]>(
-  invoke: (...args: A) => Op<T, E, []>,
-  makeIterable?: () => Op<T, E, []>,
+function makePolicyLiftedOp<T, E, A extends readonly unknown[], M = EmptyMeta>(
+  invoke: (...args: A) => Op<T, E, [], M>,
+  makeIterable?: () => Op<T, E, [], M>,
   bound = false,
-): OpInterface<T, E, A> {
+): OpInterface<T, E, A, M> {
   return makeFluentOp(
     invoke,
     (self) => ({
@@ -121,10 +122,10 @@ function makePolicyLiftedOp<T, E, A extends readonly unknown[]>(
   );
 }
 
-function makePolicyCoreOp<T, E>(
-  gen: () => Generator<Instruction<E>, T, unknown>,
-): Op<T, TrackedErr<E>, []> {
-  const self: Op<T, TrackedErr<E>, []> = makeCoreOp(
+function makePolicyCoreOp<T, E, M = EmptyMeta>(
+  gen: () => Generator<Instruction<E, M>, T, unknown>,
+): Op<T, TrackedErr<E>, [], M> {
+  const self: Op<T, TrackedErr<E>, [], M> = makeCoreOp(
     gen,
     createDefaultHooks(() => self),
   );
@@ -145,11 +146,11 @@ function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
  * - Retries only re-run the same op; the exposed typed error channel remains `E`
  * - Internally we include `UnhandledException` for runtime safety in `drive`
  */
-function withRetryCoreOp<T, E>(
-  op: Op<T, E, []>,
+function withRetryCoreOp<T, E, M>(
+  op: Op<T, E, [], M>,
   policy: RetryPolicy = DEFAULT_RETRY_POLICY,
-): Op<T, E, []> {
-  return makePolicyCoreOp(function* () {
+): Op<T, E, [], M> {
+  return makePolicyCoreOp<T, E | UnhandledException, M>(function* () {
     let attempt = 1;
 
     while (true) {
@@ -190,10 +191,13 @@ function withRetryCoreOp<T, E>(
  * - `drive` can still surface `UnhandledException` internally
  * - We intentionally expose only he public contract of `E | TimeoutError` for fluent API stability
  */
-function withTimeoutCoreOp<T, E>(op: Op<T, E, []>, timeoutMs: number): Op<T, E | TimeoutError, []> {
+function withTimeoutCoreOp<T, E, M>(
+  op: Op<T, E, [], M>,
+  timeoutMs: number,
+): Op<T, E | TimeoutError, [], M> {
   const clampedTimeoutMs = Math.max(0, timeoutMs);
 
-  return makePolicyCoreOp(function* () {
+  return makePolicyCoreOp<T, E | UnhandledException | TimeoutError, M>(function* () {
     const result: Result<T, E | UnhandledException | TimeoutError> = yield* new SuspendInstruction(
       (outerContext) =>
         raceTimeout(
@@ -213,8 +217,8 @@ function withTimeoutCoreOp<T, E>(op: Op<T, E, []>, timeoutMs: number): Op<T, E |
  *
  * - Same contract as source op: binding a signal does not widen the typed error channel
  */
-function withSignalCoreOp<T, E>(op: Op<T, E, []>, signal: AbortSignal): Op<T, E, []> {
-  return makePolicyCoreOp(function* () {
+function withSignalCoreOp<T, E, M>(op: Op<T, E, [], M>, signal: AbortSignal): Op<T, E, [], M> {
+  return makePolicyCoreOp<T, E | UnhandledException, M>(function* () {
     const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
       (outerContext) =>
         runWithBoundSignal((mergedContext) => drive(op, mergedContext), signal, outerContext),
@@ -225,13 +229,13 @@ function withSignalCoreOp<T, E>(op: Op<T, E, []>, signal: AbortSignal): Op<T, E,
   });
 }
 
-export function withRetryOp<T, E, A extends readonly unknown[]>(
-  op: Op<T, E, A>,
+export function withRetryOp<T, E, A extends readonly unknown[], M>(
+  op: Op<T, E, A, M>,
   policy: RetryPolicy = DEFAULT_RETRY_POLICY,
-): Op<T, E, A> {
+): Op<T, E, A, M> {
   // SAFETY: makePolicyLiftedOp preserves the source op arity and only changes run behavior.
   return unsafeCoerce(
-    makePolicyLiftedOp(
+    makePolicyLiftedOp<T, E, A, M>(
       (...args: A) => withRetryCoreOp(op(...args), policy),
       isIterableOp(op) ? () => withRetryCoreOp(op(), policy) : undefined,
       coerceToNullaryOp(op) !== undefined,
@@ -239,27 +243,33 @@ export function withRetryOp<T, E, A extends readonly unknown[]>(
   );
 }
 
-export function withTimeoutOp<T, E, A extends readonly unknown[]>(
-  op: Op<T, E, A>,
+export function withTimeoutOp<T, E, A extends readonly unknown[], M>(
+  op: Op<T, E, A, M>,
   timeoutMs: number,
-): Op<T, E | TimeoutError, A> {
+): Op<T, E | TimeoutError, A, M> {
   // SAFETY: makePolicyLiftedOp preserves arity while withTimeoutCoreOp widens only the error type.
   return unsafeCoerce(
-    makePolicyLiftedOp(
+    makePolicyLiftedOp<T, E | TimeoutError, A, M>(
       (...args: A) => withTimeoutCoreOp(op(...args), timeoutMs),
-      isIterableOp(op) ? () => withTimeoutCoreOp(op(), timeoutMs) : undefined,
+      isIterableOp(op)
+        ? () => {
+            // SAFETY: `isIterableOp` proves `op()` is the nullary iterable surface for this op.
+            const iterable = unsafeCoerce<Op<T, E, [], M>>(op());
+            return withTimeoutCoreOp(iterable, timeoutMs);
+          }
+        : undefined,
       coerceToNullaryOp(op) !== undefined,
     ),
   );
 }
 
-export function withSignalOp<T, E, A extends readonly unknown[]>(
-  op: Op<T, E, A>,
+export function withSignalOp<T, E, A extends readonly unknown[], M>(
+  op: Op<T, E, A, M>,
   signal: AbortSignal,
-): Op<T, E, A> {
+): Op<T, E, A, M> {
   // SAFETY: makePolicyLiftedOp preserves the source op arity and error channel.
   return unsafeCoerce(
-    makePolicyLiftedOp(
+    makePolicyLiftedOp<T, E, A, M>(
       (...args: A) => withSignalCoreOp(op(...args), signal),
       isIterableOp(op) ? () => withSignalCoreOp(op(), signal) : undefined,
       coerceToNullaryOp(op) !== undefined,
@@ -282,7 +292,11 @@ async function runWithBoundSignal<T, E>(
   outerContext: RunContext<readonly unknown[]>,
 ): Promise<Result<T, E>> {
   const controller = new AbortController();
-  const runContext = createRunContext(controller.signal, outerContext.args);
+  const runContext = createRunContext(
+    controller.signal,
+    outerContext.args,
+    outerContext.extensions,
+  );
 
   const forwardBoundAbort = () => controller.abort(boundSignal.reason);
   if (boundSignal.aborted) forwardBoundAbort();
@@ -318,7 +332,11 @@ async function raceTimeout<T, E>(
   outerContext: RunContext<readonly unknown[]>,
 ): Promise<Result<T, E | TimeoutError>> {
   const controller = new AbortController();
-  const runContext = createRunContext(controller.signal, outerContext.args);
+  const runContext = createRunContext(
+    controller.signal,
+    outerContext.args,
+    outerContext.extensions,
+  );
   const cascade = () => controller.abort(outerContext.signal.reason);
 
   if (outerContext.signal.aborted) cascade();

--- a/packages/op/src/policies.ts
+++ b/packages/op/src/policies.ts
@@ -237,7 +237,13 @@ export function withRetryOp<T, E, A extends readonly unknown[], M>(
   return unsafeCoerce(
     makePolicyLiftedOp<T, E, A, M>(
       (...args: A) => withRetryCoreOp(op(...args), policy),
-      isIterableOp(op) ? () => withRetryCoreOp(op(), policy) : undefined,
+      isIterableOp(op)
+        ? () => {
+            // SAFETY: `isIterableOp` proves `op()` is the nullary iterable surface for this op.
+            const iterable = unsafeCoerce<Op<T, E, [], M>>(op());
+            return withRetryCoreOp(iterable, policy);
+          }
+        : undefined,
       coerceToNullaryOp(op) !== undefined,
     ),
   );
@@ -271,7 +277,13 @@ export function withSignalOp<T, E, A extends readonly unknown[], M>(
   return unsafeCoerce(
     makePolicyLiftedOp<T, E, A, M>(
       (...args: A) => withSignalCoreOp(op(...args), signal),
-      isIterableOp(op) ? () => withSignalCoreOp(op(), signal) : undefined,
+      isIterableOp(op)
+        ? () => {
+            // SAFETY: `isIterableOp` proves `op()` is the nullary iterable surface for this op.
+            const iterable = unsafeCoerce<Op<T, E, [], M>>(op());
+            return withSignalCoreOp(iterable, signal);
+          }
+        : undefined,
       coerceToNullaryOp(op) !== undefined,
     ),
   );

--- a/packages/op/src/shared.ts
+++ b/packages/op/src/shared.ts
@@ -6,6 +6,13 @@ export const EMPTY_TUPLE: [] = [];
 export const OP_BRAND: unique symbol = Symbol("prodkit.op");
 export const OP_BOUND_BRAND: unique symbol = Symbol("prodkit.op.bound");
 
+export function hasOwn<T extends object, K extends PropertyKey>(
+  object: T,
+  key: K,
+): object is T & Record<K, unknown> {
+  return Object.hasOwn(object, key);
+}
+
 /**
  * Narrow `AbortSignal` / userland stand-ins across runtimes without depending on DOM `lib`s.
  *

--- a/packages/op/src/shared.ts
+++ b/packages/op/src/shared.ts
@@ -1,3 +1,4 @@
+// oxlint-disable typescript-eslint/no-explicit-any
 import type { Op } from "./index.js";
 import type { OpIterable } from "./core/types.js";
 
@@ -52,17 +53,17 @@ export const NEVER: never =
   // SAFETY: centralized `never` sentinel; callers must treat this as proof-only at the type level.
   unsafeCoerce<never>(undefined);
 
-export function isOp(value: unknown): value is Op<unknown, unknown, readonly unknown[]> {
+export function isOp(value: unknown): value is Op<any, any, readonly unknown[], any> {
   return hasBrand(value, OP_BRAND);
 }
 
 export function isIterableOp(
   value: unknown,
-): value is Op<unknown, unknown, []> & OpIterable<unknown, unknown> {
+): value is Op<any, any, [], any> & OpIterable<any, any, any> {
   return isOp(value) && Symbol.iterator in value && typeof value[Symbol.iterator] === "function";
 }
 
-export function coerceToNullaryOp(value: unknown): Op<unknown, unknown, []> | undefined {
+export function coerceToNullaryOp(value: unknown): Op<any, any, [], any> | undefined {
   if (
     !isOp(value) ||
     !(OP_BOUND_BRAND in value) ||

--- a/packages/op/src/test-utils.ts
+++ b/packages/op/src/test-utils.ts
@@ -69,3 +69,5 @@ export function trackAbortListeners(signal: AbortSignal) {
 export const invalidConcurrencies = [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY];
 
 export const TRUE: boolean = true;
+
+export const discard = (f: () => unknown): void => void f;

--- a/packages/op/src/type-test-utils.ts
+++ b/packages/op/src/type-test-utils.ts
@@ -1,0 +1,30 @@
+export type Assert<T extends true> = T;
+export type AssertFalse<T extends false> = T;
+
+export type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+export type IsNotEqual<X, Y> = true extends IsEqual<X, Y> ? false : true;
+
+export type IsTrue<T> = IsEqual<T, true>;
+export type IsFalse<T> = IsEqual<T, false>;
+
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+export type IsNotAny<T> = true extends IsAny<T> ? false : true;
+
+export type Debug<T> = { [K in keyof T]: T[K] };
+export type MergeInsertions<T> = T extends object ? { [K in keyof T]: MergeInsertions<T[K]> } : T;
+
+export type IsAlike<X, Y> = IsEqual<MergeInsertions<X>, MergeInsertions<Y>>;
+
+export type Extends<VALUE, EXPECTED> = EXPECTED extends VALUE ? true : false;
+export type IsValidArgs<
+  FUNC extends (...args: never[]) => unknown,
+  ARGS extends readonly unknown[],
+> = ARGS extends Parameters<FUNC> ? true : false;
+
+// oxlint-disable-next-line typescript/no-explicit-any - test utility
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;

--- a/packages/std/CHANGELOG.md
+++ b/packages/std/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 
-- Renamed DI terminology to dependency-first language (`DI.Dependency`, `DI.singleton`, `MissingDependencyError`, `RequireDependency`, `Binding`, `DependencyReq`, `InferDependencyNeeds`) and aligned internal op helpers around `createDependencyOp` / `buildDependencyOp`.
+- Changed dependency-aware programs to use plain `Op(...)` from `@prodkit/op` with `yield* DI.require(Dependency)`.
+- Changed dependency provisioning to use `DI.provide(op, ...bindings)`.
+- Removed `DI.Op` and `.use(...)`; no dependency-aware wrapper operation path remains.
+- Added core metadata inference and propagation so DI requirements flow through plain `Op(...)`, nested `yield* op`, and fluent composition.
+- Renamed DI terminology to dependency-first language (`DI.Dependency`, `DI.singleton`, `MissingDependencyError`, `RequireDependency`, `Binding`, `DependencyReq`, `InferDependencyNeeds`).
 - Removed the local abort-signal stub; `.withSignal` uses `AbortSignalLike` from `@prodkit/op/internal`.
 - Replaced local `unsafeCoerce` usage with `@prodkit/op/internal` so helpers stay centralized.
 - Changed `@prodkit/op` to a peer dependency so consumers install a single compatible `@prodkit/op` alongside `@prodkit/std`.
-- Added the initial `@prodkit/std` package with `@prodkit/std/di` helpers for yieldable dependency tokens and dependency-aware `Op` wrappers.
+- Added the initial `@prodkit/std` package with `@prodkit/std/di` helpers for yieldable dependency tokens.
 - Added DI regression coverage for defaulted and rest-parameter dependency operations.
-- Changed DI provisioning to use `DI.Dependency(...)`, `DI.singleton(Dependency, value)` binding values, direct dependency implementation instances in `.use(...)`, and variadic `.use(...)` calls.
+- Changed DI provisioning to use `DI.Dependency(...)`, `DI.singleton(Dependency, value)` binding values, direct dependency implementation instances, and variadic provisioning calls.
 - Added `DI.scoped(Dependency, resolve)` for scoped (per-run) dependency resolution with in-run memoization.
 - Changed DI operation construction to avoid inspecting generator `Function.length`.

--- a/packages/std/CHANGELOG.md
+++ b/packages/std/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Changed dependency provisioning to use `DI.provide(op, ...bindings)`.
 - Removed `DI.Op` and `.use(...)`; no dependency-aware wrapper operation path remains.
 - Added core metadata inference and propagation so DI requirements flow through plain `Op(...)`, nested `yield* op`, and fluent composition.
-- Renamed DI terminology to dependency-first language (`DI.Dependency`, `DI.singleton`, `MissingDependencyError`, `RequireDependency`, `Binding`, `DependencyReq`, `InferDependencyNeeds`).
+- Renamed DI terminology to dependency-first language (`DI.Dependency`, `DI.singleton`, `MissingDependencyError`, `RequireDependency`, `Binding`, `DependencyReq`, `InferDependencyBlocking`).
 - Removed the local abort-signal stub; `.withSignal` uses `AbortSignalLike` from `@prodkit/op/internal`.
 - Replaced local `unsafeCoerce` usage with `@prodkit/op/internal` so helpers stay centralized.
 - Changed `@prodkit/op` to a peer dependency so consumers install a single compatible `@prodkit/op` alongside `@prodkit/std`.
@@ -16,6 +16,6 @@
 - Changed DI provisioning to use `DI.Dependency(...)`, `DI.singleton(Dependency, value)` binding values, direct dependency implementation instances, and variadic provisioning calls.
 - Added `DI.scoped(Dependency, resolve)` for scoped (per-run) dependency resolution with in-run memoization.
 - Changed DI operation construction to avoid inspecting generator `Function.length`.
-- Dependency-aware ops carry the internal `di` needs latch until `DI.provide(...)` satisfies all
-  requirements; `.run()` is unavailable until then. Clearing `di` does not clear other extension
-  namespaces on the same op.
+- Dependency-aware ops carry `requirements: Blocking<...>` until `DI.provide(...)` satisfies all
+  requirements; `.run()` is unavailable until then. Clearing requirements does not clear other
+  `Blocking<T>` metadata keys on the same op.

--- a/packages/std/CHANGELOG.md
+++ b/packages/std/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Changed dependency-aware programs to use plain `Op(...)` from `@prodkit/op` with `yield* DI.require(Dependency)`.
+- Renamed `DI.require` to `DI.inject` for requesting dependency bindings.
+- Changed dependency-aware programs to use plain `Op(...)` from `@prodkit/op` with `yield* DI.inject(Dependency)`.
 - Changed dependency provisioning to use `DI.provide(op, ...bindings)`.
 - Removed `DI.Op` and `.use(...)`; no dependency-aware wrapper operation path remains.
 - Added core metadata inference and propagation so DI requirements flow through plain `Op(...)`, nested `yield* op`, and fluent composition.

--- a/packages/std/CHANGELOG.md
+++ b/packages/std/CHANGELOG.md
@@ -16,3 +16,6 @@
 - Changed DI provisioning to use `DI.Dependency(...)`, `DI.singleton(Dependency, value)` binding values, direct dependency implementation instances, and variadic provisioning calls.
 - Added `DI.scoped(Dependency, resolve)` for scoped (per-run) dependency resolution with in-run memoization.
 - Changed DI operation construction to avoid inspecting generator `Function.length`.
+- Dependency-aware ops carry the internal `di` needs latch until `DI.provide(...)` satisfies all
+  requirements; `.run()` is unavailable until then. Clearing `di` does not clear other extension
+  namespaces on the same op.

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -13,7 +13,7 @@ interface Database {
 class DatabaseDependency extends DI.Dependency("DatabaseDependency")<Database> {}
 
 const getUser = Op(function* () {
-  const db = yield* DI.require(DatabaseDependency);
+  const db = yield* DI.inject(DatabaseDependency);
   return yield* db.query("select * from users where id = ?", [1]);
 });
 

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -3,8 +3,8 @@
 Standard library utilities for `@prodkit/op`.
 
 ```ts
-import { DI } from "@prodkit/std/di";
 import { Op } from "@prodkit/op";
+import { DI } from "@prodkit/std/di";
 
 interface Database {
   query: Op<unknown, DatabaseError, [sql: string, params: unknown[]]>;
@@ -12,12 +12,12 @@ interface Database {
 
 class DatabaseDependency extends DI.Dependency("DatabaseDependency")<Database> {}
 
-const getUser = DI.Op(function* () {
+const getUser = Op(function* () {
   const db = yield* DI.require(DatabaseDependency);
   return yield* db.query("select * from users where id = ?", [1]);
 });
 
-const runnable = getUser.use(DI.singleton(DatabaseDependency, db));
+const runnable = DI.provide(getUser, DI.singleton(DatabaseDependency, db));
 const result = await runnable.run();
 ```
 
@@ -25,10 +25,11 @@ Lifetimes:
 
 - `DI.singleton(Dependency, value)` binds one value reused across runs.
 - `DI.scoped(Dependency, resolve)` resolves once per op run and caches for that run.
-- `op.use(new DependencyImpl())` binds a class instance directly (useful when an implementation class extends the dependency token).
+- `DI.provide(op, new DependencyImpl())` binds a class instance directly when an implementation class extends the dependency token.
 
 ```ts
-const op = getUser.use(
+const op = DI.provide(
+  getUser,
   DI.scoped(DatabaseDependency, () => connectDatabase()),
 );
 

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -41,7 +41,6 @@
   },
   "scripts": {
     "build": "tsdown",
-    "gate": "pnpm run build && pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run fmt:check",
     "fix": "pnpm run lint:fix && pnpm run fmt",
     "fmt": "oxfmt \"src/**/*.ts\" \"*.ts\"",
     "fmt:check": "oxfmt --check \"src/**/*.ts\" \"*.ts\"",

--- a/packages/std/src/di/index.test.ts
+++ b/packages/std/src/di/index.test.ts
@@ -130,7 +130,8 @@ describe("DI cutover runtime", () => {
 
     const partiallyProvided = DI.provide(op, DI.singleton(DatabaseDependency, makeDatabase()));
     const result = await DI.provide(
-      partiallyProvided as typeof op,
+      partiallyProvided,
+      // @ts-expect-error - op has no remaining requirements, specifically testing the runtime guard
       DI.singleton(DatabaseDependency, makeDatabase()),
     ).run();
     const cause = getUnhandledCause(result);

--- a/packages/std/src/di/index.test.ts
+++ b/packages/std/src/di/index.test.ts
@@ -56,6 +56,7 @@ describe("DI cutover runtime", () => {
       return "unreachable";
     });
 
+    // @ts-expect-error - intentional runtime check for missing provision
     const result = await op.run();
     const cause = getUnhandledCause(result);
 

--- a/packages/std/src/di/index.test.ts
+++ b/packages/std/src/di/index.test.ts
@@ -1,10 +1,8 @@
-import { assert, describe, expect, expectTypeOf, test } from "vitest";
-import ts from "typescript";
+import { assert, describe, expect, test } from "vitest";
 import { Op, TimeoutError } from "@prodkit/op";
 import { UnhandledException } from "better-result";
-import * as std from "../index.js";
-import { InferReqs, MissingDependencyError, type DependencyValue } from "./internal.js";
-import { DI, type Dependency } from "./index.js";
+import { DI } from "./index.js";
+import { AlreadyProvidedError, MissingDependencyError } from "./internal.js";
 
 class DatabaseError extends Error {
   readonly _tag = "DatabaseError";
@@ -19,436 +17,209 @@ interface Database {
 }
 
 class DatabaseDependency extends DI.Dependency("DatabaseDependency")<Database> {}
+class LoggerDependency extends DI.Dependency("LoggerDependency")<{
+  log: (message: string) => void;
+}> {}
 
-describe("DI", () => {
-  test("keeps dependency names as discriminators", () => {
-    expectTypeOf(DatabaseDependency).toExtend<Dependency<Database, "DatabaseDependency">>();
-    expectTypeOf<DependencyValue<typeof DatabaseDependency>>().toEqualTypeOf<Database>();
-  });
+const makeDatabase = (calls: string[] = []): Database => ({
+  query: Op(function* (sql: string, params: unknown[]) {
+    calls.push(`${sql}:${params[0]}`);
+    return { id: String(params[0]) };
+  }).mapErr((error): DatabaseError => error),
+});
 
-  test("exports dependency injection helpers from the root namespace", () => {
-    expect(std.DI.DI).toBe(DI);
-    expect(std.DI.Dependency).toBe(DI.Dependency);
-  });
+function getUnhandledCause(result: Awaited<ReturnType<Op<unknown, unknown, []>["run"]>>): unknown {
+  assert(result.isErr(), "result should be Err");
+  assert(UnhandledException.is(result.error));
+  return result.error.cause;
+}
 
-  test("infers dependency needs from yielded dependencies", () => {
-    const op = DI.Op(function* () {
+describe("DI cutover runtime", () => {
+  test("plain Op can require and run with provided singleton dependencies", async () => {
+    const calls: string[] = [];
+    const op = Op(function* (id: string) {
       const db = yield* DI.require(DatabaseDependency);
-      return yield* db.query("select * from users where id = ?", ["1"]);
+      return yield* db.query("user", [id]);
     });
 
-    expectTypeOf(op).toEqualTypeOf<DI.Op<User, DatabaseError, [], DatabaseDependency>>();
-
-    const provided = op.use(
-      DI.singleton(DatabaseDependency, {
-        query: Op(function* (_sql: string, _params: unknown[]) {
-          return { id: "1" };
-        }).mapErr((error): DatabaseError => error),
-      }),
+    const result = await DI.provide(op, DI.singleton(DatabaseDependency, makeDatabase(calls))).run(
+      "123",
     );
 
-    expectTypeOf(provided).toEqualTypeOf<DI.Op<User, DatabaseError, [], never>>();
-    expectTypeOf(provided.run()).toEqualTypeOf<ReturnType<Op<User, DatabaseError, []>["run"]>>();
-  });
-
-  test("runs with provided dependencies", async () => {
-    const calls: string[] = [];
-    const db: Database = {
-      query: Op(function* (sql: string, params: unknown[]) {
-        calls.push(`${sql}:${params[0]}`);
-        return { id: String(params[0]) };
-      }).mapErr((error): DatabaseError => error),
-    };
-    const op = DI.Op(function* (id: string) {
-      const dependency = yield* DI.require(DatabaseDependency);
-      return yield* dependency.query("user", [id]);
-    }).use(DI.singleton(DatabaseDependency, db));
-
-    const result = await op.run("123");
-
-    expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toEqual({ id: "123" });
     expect(calls).toEqual(["user:123"]);
   });
 
-  test("accepts dependency implementations directly in use(...)", async () => {
-    class InMemoryDatabaseDependency extends DatabaseDependency implements Database {
+  test("missing dependency returns UnhandledException with MissingDependencyError cause", async () => {
+    const op = Op(function* () {
+      yield* DI.require(DatabaseDependency);
+      return "unreachable";
+    });
+
+    const result = await op.run();
+    const cause = getUnhandledCause(result);
+
+    assert(MissingDependencyError.is(cause));
+    expect(cause.key).toBe("DatabaseDependency");
+  });
+
+  test("direct dependency implementation instances resolve correctly", async () => {
+    class InMemoryDatabase extends DatabaseDependency implements Database {
       query = Op(function* (_sql: string, params: unknown[]) {
         return { id: String(params[0]) };
       }).mapErr((error): DatabaseError => error);
     }
 
-    const op = DI.Op(function* (id: string) {
+    const op = Op(function* (id: string) {
       const db = yield* DI.require(DatabaseDependency);
       return yield* db.query("user", [id]);
-    }).use(new InMemoryDatabaseDependency());
+    });
 
-    expectTypeOf(op).toEqualTypeOf<DI.Op<User, DatabaseError, [id: string], never>>();
+    const result = await DI.provide(op, new InMemoryDatabase()).run("456");
 
-    const result = await op.run("456");
     expect(result.unwrap()).toEqual({ id: "456" });
   });
 
-  test("lazy dependencies resolve once per run and re-evaluate on next run", async () => {
+  test("scoped dependencies resolve once per run and again on the next run", async () => {
     let resolves = 0;
-    const op = DI.Op(function* (id: string) {
+    const op = Op(function* (id: string) {
       const db1 = yield* DI.require(DatabaseDependency);
       const db2 = yield* DI.require(DatabaseDependency);
       expect(db1).toBe(db2);
       return yield* db1.query("user", [id]);
-    }).use(
+    });
+    const runnable = DI.provide(
+      op,
       DI.scoped(DatabaseDependency, () => {
         resolves += 1;
-        return {
-          query: Op(function* (_sql: string, params: unknown[]) {
-            return { id: String(params[0]) };
-          }).mapErr((error): DatabaseError => error),
-        } satisfies Database;
+        return makeDatabase();
       }),
     );
 
-    const first = await op.run("a");
-    const second = await op.run("b");
-
-    expect(first.unwrap()).toEqual({ id: "a" });
-    expect(second.unwrap()).toEqual({ id: "b" });
+    expect((await runnable.run("a")).unwrap()).toEqual({ id: "a" });
+    expect((await runnable.run("b")).unwrap()).toEqual({ id: "b" });
     expect(resolves).toBe(2);
   });
 
-  test("lazy dependency factory failures surface as unhandled runtime failures", async () => {
-    const op = DI.Op(function* () {
-      yield* DI.require(DatabaseDependency);
-      return "unreachable";
-    }).use(
-      DI.scoped(DatabaseDependency, () => {
-        throw new Error("boom");
-      }),
-    );
-
-    const result = await op.run();
-    expect(result.isErr()).toBe(true);
-    const error = result.match({
-      ok: () => undefined,
-      err: (err) => err,
-    });
-    assert(UnhandledException.is(error));
-    assert(error.cause instanceof Error);
-    expect(error.cause.message).toContain("boom");
-  });
-
-  test("defaulted generator params still receive explicit run args", async () => {
-    const op = DI.Op(function* (id: string = "default") {
-      return id;
-    }) satisfies DI.Op<string, never, [id?: string | undefined], never>;
-
-    const result = await op.run("explicit");
-
-    expect(result.unwrap()).toBe("explicit");
-  });
-
-  test("rest-parameter generators preserve all run args", async () => {
-    const op = DI.Op(function* (...values: number[]) {
-      return values.reduce((sum, value) => sum + value, 0);
-    });
-
-    expectTypeOf(op).toEqualTypeOf<DI.Op<number, never, number[], never>>();
-
-    const result = await op.run(1, 2, 3, 4);
-
-    expect(result.unwrap()).toBe(10);
-  });
-
-  test("composes dependency-aware operations", async () => {
-    const findUser = DI.Op(function* (id: string) {
+  test("nested DI.provide calls merge bindings", async () => {
+    const seen: string[] = [];
+    const op = Op(function* (id: string) {
       const db = yield* DI.require(DatabaseDependency);
-      return yield* db.query("user", [id]);
+      const logger = yield* DI.require(LoggerDependency);
+      const user = yield* db.query("user", [id]);
+      logger.log(user.id);
+      return user;
     });
-    const greet = DI.Op(function* (id: string) {
-      const user = yield* findUser(id);
-      return `hello ${user.id}`;
-    });
-    const runnable = greet.use(
-      DI.singleton(DatabaseDependency, {
-        query: Op(function* (_sql: string, params: unknown[]) {
-          return { id: String(params[0]) };
-        }).mapErr((error): DatabaseError => error),
-      }),
+
+    const runnable = DI.provide(
+      DI.provide(op, DI.singleton(DatabaseDependency, makeDatabase())),
+      DI.singleton(LoggerDependency, { log: (message) => seen.push(message) }),
     );
 
     const result = await runnable.run("abc");
 
-    expect(result.unwrap()).toBe("hello abc");
+    expect(result.unwrap()).toEqual({ id: "abc" });
+    expect(seen).toEqual(["abc"]);
   });
 
-  test("fluent callbacks can return dependency-aware operations", async () => {
-    const findUser = DI.Op(function* (id: string) {
+  test("duplicate provisioning returns UnhandledException with AlreadyProvidedError cause", async () => {
+    const op = Op(function* () {
       const db = yield* DI.require(DatabaseDependency);
-      return yield* db.query("user", [id]);
+      return yield* db.query("user", ["1"]);
     });
-    const greet = DI.Op(function* () {
-      return "abc";
-    })
-      .flatMap((id) => findUser(id))
-      .map((user) => `hello ${user.id}`);
 
-    expectTypeOf(greet).toEqualTypeOf<DI.Op<string, DatabaseError, [], DatabaseDependency>>();
+    const partiallyProvided = DI.provide(op, DI.singleton(DatabaseDependency, makeDatabase()));
+    const result = await DI.provide(
+      partiallyProvided as typeof op,
+      DI.singleton(DatabaseDependency, makeDatabase()),
+    ).run();
+    const cause = getUnhandledCause(result);
 
-    const result = await greet
-      .use(
-        DI.singleton(DatabaseDependency, {
-          query: Op(function* (_sql: string, params: unknown[]) {
-            return { id: String(params[0]) };
-          }).mapErr((error): DatabaseError => error),
-        }),
-      )
-      .run();
-
-    expect(result.unwrap()).toBe("hello abc");
+    assert(AlreadyProvidedError.is(cause));
+    expect(cause.key).toBe("DatabaseDependency");
   });
 
-  test("policy wrappers can be configured before or after dependency wiring", async () => {
-    const db: Database = {
-      query: Op(function* (_sql: string, params: unknown[]) {
-        return { id: String(params[0]) };
-      }).mapErr((error): DatabaseError => error),
-    };
-    const findUser = DI.Op(function* (id: string) {
+  test("policy, lifecycle, release, and fluent paths keep DI context", async () => {
+    const db = makeDatabase();
+    const findUser = Op(function* (id: string) {
       const dependency = yield* DI.require(DatabaseDependency);
       return yield* dependency.query("user", [id]);
     });
 
-    const policyBeforeProvisioning = findUser
-      .withTimeout(1_000)
-      .use(DI.singleton(DatabaseDependency, db));
-    expectTypeOf(policyBeforeProvisioning).toEqualTypeOf<
-      DI.Op<User, DatabaseError | TimeoutError, [id: string], never>
-    >();
-
-    const policyAfterProvisioning = findUser
-      .use(DI.singleton(DatabaseDependency, db))
-      .withTimeout(1_000);
-    expectTypeOf(policyAfterProvisioning).toEqualTypeOf<
-      DI.Op<User, DatabaseError | TimeoutError, [id: string], never>
-    >();
-
-    const before = await policyBeforeProvisioning.run("before");
-    const after = await policyAfterProvisioning.run("after");
-
-    expect(before.unwrap()).toEqual({ id: "before" });
-    expect(after.unwrap()).toEqual({ id: "after" });
-  });
-
-  test("all dependencies are required", async () => {
-    class TestDependency1 extends DI.Dependency("TestDependency1")<{}> {}
-    class TestDependency2 extends DI.Dependency("TestDependency2")<{}> {}
-    class TestDependency3 extends DI.Dependency("TestDependency3")<{}> {}
-
-    const op = DI.Op(function* () {
-      yield* DI.require(TestDependency1);
-      yield* DI.require(TestDependency2);
-      yield* DI.require(TestDependency3);
-    });
-
-    expectTypeOf(op).toEqualTypeOf<
-      DI.Op<void, never, [], TestDependency1 | TestDependency2 | TestDependency3>
-    >();
-
-    type OpRequirements = InferReqs<typeof op>;
-    expectTypeOf<OpRequirements>().toEqualTypeOf<
-      TestDependency1 | TestDependency2 | TestDependency3
-    >();
-
-    const provided = op.use(DI.singleton(TestDependency1, {}));
-    expectTypeOf(provided).toEqualTypeOf<
-      DI.Op<void, never, [], TestDependency2 | TestDependency3>
-    >();
-
-    type ProvidedRequirements = InferReqs<typeof provided>;
-    expectTypeOf<ProvidedRequirements>().toEqualTypeOf<TestDependency2 | TestDependency3>();
-
-    // @ts-expect-error - still missing TestDependency2 and TestDependency3
-    void (await provided.run());
-
-    const provided2 = op.use(DI.singleton(TestDependency1, {}), DI.singleton(TestDependency2, {}));
-    expectTypeOf(provided2).toEqualTypeOf<DI.Op<void, never, [], TestDependency3>>();
-    type Provided2Requirements = InferReqs<typeof provided2>;
-    expectTypeOf<Provided2Requirements>().toEqualTypeOf<TestDependency3>();
-
-    // @ts-expect-error - still missing TestDependency3
-    void (await provided2.run());
-
-    const provided3 = provided2.use(DI.singleton(TestDependency3, {}));
-    expectTypeOf(provided3).toEqualTypeOf<DI.Op<void, never, [], never>>();
-
-    const result = await provided3.run();
-    expect(result.isOk()).toBe(true);
-  });
-
-  test("missing dependencies surface as unhandled runtime failures", async () => {
-    const op = DI.Op(function* () {
-      yield* DI.require(DatabaseDependency);
-      return "unreachable";
-    });
-
-    const runnable = op as unknown as Op<string, never, []>;
-    const result = await runnable.run();
-
-    expect(result.isErr()).toBe(true);
-    const error = result.match({
-      ok: () => undefined,
-      err: (err) => err,
-    });
-    assert(UnhandledException.is(error));
-    assert(MissingDependencyError.is(error.cause));
-    expect(error.cause.key).toBe("DatabaseDependency");
-  });
-
-  test("yielding a dependency class without DI.require surfaces the static iterator guard", async () => {
-    const op = DI.Op(function* () {
-      // @ts-expect-error - DatabaseDependency does not have a [Symbol.iterator] method
-      const _db = yield* DatabaseDependency;
-      return "unreachable";
-    });
-
-    // @ts-expect-error - requirements are unknown
-    const result = await op.run();
-
-    expect(result.isErr()).toBe(true);
-    const error = result.match({
-      ok: () => undefined,
-      err: (err: unknown) => err,
-    });
-    assert(UnhandledException.is(error));
-    // @ts-expect-error - console is not defined in the test environment
-    // oxlint-disable-next-line no-console
-    console.log(error.cause);
-    expect(error.cause).toBeInstanceOf(TypeError);
-    expect(String(error.cause)).toContain(
-      "Use DI.require(dependency) to require a dependency binding",
-    );
-  });
-});
-
-describe("DI implementation hygiene", () => {
-  test("does not inspect generator Function.length", () => {
-    const source = ts.sys.readFile(`${ts.sys.getCurrentDirectory()}/src/di/index.ts`);
-
-    expect(source).not.toContain("f.length");
-  });
-
-  test("quick info for composed operations shows resolved dependency requirements", () => {
-    const cwd = ts.sys.getCurrentDirectory();
-    const configPath = `${cwd}/tsconfig.json`;
-    const sourcePath = `${cwd}/src/di/index.test.ts`;
-    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
-
-    if (configFile.error) {
-      throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
-    }
-
-    const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, cwd);
-    const sourceText = ts.sys.readFile(sourcePath);
-    expect(sourceText).toBeDefined();
-    if (sourceText === undefined) return;
-
-    const sourceFile = ts.createSourceFile(
-      sourcePath,
-      sourceText,
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TS,
-    );
-
-    let composedPosition = -1;
-    const visit = (node: ts.Node): void => {
-      if (
-        ts.isVariableDeclaration(node) &&
-        ts.isIdentifier(node.name) &&
-        node.name.text === "composed"
-      ) {
-        composedPosition = node.name.getStart(sourceFile) + 1;
-      }
-      ts.forEachChild(node, visit);
+    const signal: Parameters<typeof findUser.withSignal>[0] = {
+      aborted: false,
+      reason: undefined,
+      addEventListener: () => {},
+      removeEventListener: () => {},
     };
-    visit(sourceFile);
-    expect(composedPosition).toBeGreaterThan(0);
+    const cases = [
+      DI.provide(
+        findUser.withRetry({ maxAttempts: 1, shouldRetry: () => true, getDelay: () => 0 }),
+        DI.singleton(DatabaseDependency, db),
+      ),
+      DI.provide(findUser.withTimeout(1_000), DI.singleton(DatabaseDependency, db)),
+      DI.provide(findUser.withSignal(signal), DI.singleton(DatabaseDependency, db)),
+      DI.provide(
+        findUser.withRelease(() => {}),
+        DI.singleton(DatabaseDependency, db),
+      ),
+      DI.provide(
+        findUser.on("enter", () => {}),
+        DI.singleton(DatabaseDependency, db),
+      ),
+      DI.provide(
+        findUser.on("exit", () => {}),
+        DI.singleton(DatabaseDependency, db),
+      ),
+      DI.provide(findUser, DI.singleton(DatabaseDependency, db)).withRetry({
+        maxAttempts: 1,
+        shouldRetry: () => true,
+        getDelay: () => 0,
+      }),
+      DI.provide(findUser, DI.singleton(DatabaseDependency, db)).withTimeout(1_000),
+      DI.provide(findUser, DI.singleton(DatabaseDependency, db)).withSignal(signal),
+      DI.provide(findUser, DI.singleton(DatabaseDependency, db)).withRelease(() => {}),
+      DI.provide(findUser, DI.singleton(DatabaseDependency, db)).on("enter", () => {}),
+      DI.provide(findUser, DI.singleton(DatabaseDependency, db)).on("exit", () => {}),
+    ];
 
-    const servicesHost: ts.LanguageServiceHost = {
-      getScriptFileNames: () => parsed.fileNames,
-      getScriptVersion: () => "0",
-      getScriptSnapshot: (fileName) => {
-        if (!ts.sys.fileExists(fileName)) return undefined;
-        return ts.ScriptSnapshot.fromString(ts.sys.readFile(fileName) ?? "");
-      },
-      getCurrentDirectory: () => cwd,
-      getCompilationSettings: () => parsed.options,
-      getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
-      fileExists: ts.sys.fileExists,
-      readFile: ts.sys.readFile,
-      readDirectory: ts.sys.readDirectory,
-    };
+    for (const [index, candidate] of cases.entries()) {
+      const result = await candidate.run(`id-${index}`);
+      expect(result.unwrap()).toEqual({ id: `id-${index}` });
+    }
 
-    const languageService = ts.createLanguageService(servicesHost, ts.createDocumentRegistry());
-    const quickInfo = languageService.getQuickInfoAtPosition(sourcePath, composedPosition);
-    expect(quickInfo).toBeDefined();
-    if (quickInfo === undefined) return;
-
-    const display = ts.displayPartsToString(quickInfo.displayParts ?? []);
-    expect(display).toBe(
-      "const composed: DI.Op<string, DatabaseError, [], DatabaseDependency | TestDependency>",
-    );
+    expect(
+      await DI.provide(
+        findUser("flat").flatMap(() => findUser("next")),
+        DI.singleton(DatabaseDependency, db),
+      ).run(),
+    ).toEqual(expect.objectContaining({ value: { id: "next" } }));
+    expect(
+      await DI.provide(
+        findUser("tap").tap(() => findUser("observed")),
+        DI.singleton(DatabaseDependency, db),
+      ).run(),
+    ).toEqual(expect.objectContaining({ value: { id: "tap" } }));
+    expect(
+      await DI.provide(
+        Op.fail("recover" as const).recover(
+          (error): error is "recover" => error === "recover",
+          () => findUser("recovered"),
+        ),
+        DI.singleton(DatabaseDependency, db),
+      ).run(),
+    ).toEqual(expect.objectContaining({ value: { id: "recovered" } }));
   });
-});
 
-describe("composition", () => {
-  test("dependencies bubble up to the operation return type", () => {
-    const op1 = DI.Op(function* () {
-      const db = yield* DI.require(DatabaseDependency);
-      return yield* db.query("select * from users where id = ?", ["1"]);
-    });
+  test("timeout typing remains available around provisioned ops", () => {
+    const op = DI.provide(
+      Op(function* () {
+        yield* DI.require(DatabaseDependency);
+      }),
+      DI.singleton(DatabaseDependency, makeDatabase()),
+    ).withTimeout(1);
 
-    expectTypeOf(op1).toEqualTypeOf<DI.Op<User, DatabaseError, [], DatabaseDependency>>();
-
-    class TestDependency extends DI.Dependency("TestDependency")<{ a: string }> {}
-    const op2 = DI.Op(function* () {
-      const db = yield* DI.require(TestDependency);
-      return db.a;
-    });
-
-    expectTypeOf(op2).toEqualTypeOf<DI.Op<string, never, [], TestDependency>>();
-
-    // this name must not change for the hygiene test above to pass
-    const composed = DI.Op(function* () {
-      const a = yield* op1;
-      const b = yield* op2;
-      return `${a} ${b}`;
-    });
-
-    expectTypeOf(composed).toEqualTypeOf<
-      DI.Op<string, DatabaseError, [], DatabaseDependency | TestDependency>
-    >();
-
-    type TestDependency2Value = { b: string };
-    class TestDependency2 extends DI.Dependency("TestDependency2")<TestDependency2Value> {}
-    class TestDep2Impl extends TestDependency2 implements TestDependency2Value {
-      b = "b";
-    }
-    const TestDep2Impl2 = DI.singleton(TestDependency2, { b: "b" });
-    // @ts-expect-error - TestDep2Impl is not a Dependency
-    const _a = composed.use(TestDep2Impl);
-    // @ts-expect-error - TestDep2Impl is not a Dependency
-    const _b = composed.use(new TestDep2Impl());
-    // @ts-expect-error - TestDep2Impl2 is not a Dependency
-    const _c = composed.use(TestDep2Impl2);
-
-    const TestDepImpl = DI.singleton(TestDependency, { a: "a" });
-    const _d = composed.use(TestDepImpl); // ok
-    type TestDepImplValue = { a: string };
-    class TestDepImpl2 extends TestDependency implements TestDepImplValue {
-      a = "a";
-    }
-    const _e = composed.use(new TestDepImpl2()); // ok
-    const _f = composed.use(DI.singleton(TestDependency, { a: "a" })); // ok
-    const _g = composed.use(TestDepImpl2); // ok
+    const _timeout: Op<void, TimeoutError, []> = op;
+    expect(_timeout).toBe(op);
   });
 });

--- a/packages/std/src/di/index.test.ts
+++ b/packages/std/src/di/index.test.ts
@@ -38,7 +38,7 @@ describe("DI cutover runtime", () => {
   test("plain Op can require and run with provided singleton dependencies", async () => {
     const calls: string[] = [];
     const op = Op(function* (id: string) {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", [id]);
     });
 
@@ -52,7 +52,7 @@ describe("DI cutover runtime", () => {
 
   test("missing dependency returns UnhandledException with MissingDependencyError cause", async () => {
     const op = Op(function* () {
-      yield* DI.require(DatabaseDependency);
+      yield* DI.inject(DatabaseDependency);
       return "unreachable";
     });
 
@@ -71,7 +71,7 @@ describe("DI cutover runtime", () => {
     }
 
     const op = Op(function* (id: string) {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", [id]);
     });
 
@@ -83,8 +83,8 @@ describe("DI cutover runtime", () => {
   test("scoped dependencies resolve once per run and again on the next run", async () => {
     let resolves = 0;
     const op = Op(function* (id: string) {
-      const db1 = yield* DI.require(DatabaseDependency);
-      const db2 = yield* DI.require(DatabaseDependency);
+      const db1 = yield* DI.inject(DatabaseDependency);
+      const db2 = yield* DI.inject(DatabaseDependency);
       expect(db1).toBe(db2);
       return yield* db1.query("user", [id]);
     });
@@ -104,8 +104,8 @@ describe("DI cutover runtime", () => {
   test("nested DI.provide calls merge bindings", async () => {
     const seen: string[] = [];
     const op = Op(function* (id: string) {
-      const db = yield* DI.require(DatabaseDependency);
-      const logger = yield* DI.require(LoggerDependency);
+      const db = yield* DI.inject(DatabaseDependency);
+      const logger = yield* DI.inject(LoggerDependency);
       const user = yield* db.query("user", [id]);
       logger.log(user.id);
       return user;
@@ -124,7 +124,7 @@ describe("DI cutover runtime", () => {
 
   test("duplicate provisioning returns UnhandledException with AlreadyProvidedError cause", async () => {
     const op = Op(function* () {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", ["1"]);
     });
 
@@ -143,7 +143,7 @@ describe("DI cutover runtime", () => {
   test("policy, lifecycle, release, and fluent paths keep DI context", async () => {
     const db = makeDatabase();
     const findUser = Op(function* (id: string) {
-      const dependency = yield* DI.require(DatabaseDependency);
+      const dependency = yield* DI.inject(DatabaseDependency);
       return yield* dependency.query("user", [id]);
     });
 
@@ -215,7 +215,7 @@ describe("DI cutover runtime", () => {
   test("timeout typing remains available around provisioned ops", () => {
     const op = DI.provide(
       Op(function* () {
-        yield* DI.require(DatabaseDependency);
+        yield* DI.inject(DatabaseDependency);
       }),
       DI.singleton(DatabaseDependency, makeDatabase()),
     ).withTimeout(1);

--- a/packages/std/src/di/index.ts
+++ b/packages/std/src/di/index.ts
@@ -1,53 +1,27 @@
+// oxlint-disable typescript-eslint/no-explicit-any
 import { NEVER } from "@prodkit/op/internal";
-import type { Op as OgOp } from "@prodkit/op";
-import { InferErr as InferResultErr } from "better-result";
+import type { Op as CoreOp } from "@prodkit/op";
 import {
-  DI_TOKEN,
   DI_TAG,
-  buildDependencyOp,
-  createDependencyOp,
+  DI_TOKEN,
   DependencyReqInstruction,
-  type DiOpBase,
-  type ConditionalIterable,
-  type DependencyCtor,
-  type DependencyValue,
-  type Binding,
-  type LazyBinding,
+  provideOp,
   type AnyDependency,
+  type Binding,
+  type DependencyCtor,
   type DependencyReq,
-  type InferEmbedErr,
-  type EmbedDiOpInstruction,
-} from "./internal";
+  type DependencyValue,
+  type LazyBinding,
+  type ProvidedMeta,
+  type UseEntry,
+  type ValidUseEntries,
+} from "./internal.js";
 
 export interface Dependency<T, Name extends string> {
   readonly _tag: typeof DI_TAG;
   readonly key: Name;
   readonly [DI_TOKEN]: T;
 }
-
-export namespace DI {
-  export type Op<T, E, A extends readonly unknown[], R> = DiOpBase<T, E, A, R> &
-    ConditionalIterable<T, E, A, R> & { readonly [DI_TOKEN]: T };
-}
-
-export const Op = <Y, T, A extends readonly unknown[]>(
-  f: (...args: A) => Generator<Y, T, unknown>,
-): DI.Op<
-  T,
-  InferResultErr<Y> | InferEmbedErr<Y>,
-  A,
-  Y extends unknown
-    ?
-        | (Y extends DependencyReqInstruction<unknown, infer R> ? R : never)
-        | (Y extends EmbedDiOpInstruction<unknown, unknown, infer R> ? R : never)
-    : never
-> =>
-  createDependencyOp({
-    buildOp: (env) => buildDependencyOp(f, env),
-    env: new Map(),
-    iterable: true,
-  });
-export type Op<T, E, A extends readonly unknown[], R> = DI.Op<T, E, A, R>;
 
 export const Dependency = <const Name extends string>(key: Name): DependencyCtor<Name> => {
   class DependencyToken<T> {
@@ -99,21 +73,18 @@ export const scoped = <C extends AnyDependency, V = unknown>(
   resolve,
 });
 
-export const provide = <T, E, A extends readonly unknown[], R>(
-  op: DI.Op<T, E, A, R>,
-  ...entries: Array<
-    | Binding<Extract<R, AnyDependency>, DependencyValue<Extract<R, AnyDependency>>>
-    | LazyBinding<Extract<R, AnyDependency>, DependencyValue<Extract<R, AnyDependency>>>
-  >
-): DI.Op<
+export const provide = <
   T,
   E,
-  A,
-  Exclude<R, DependencyReq<Extract<R, AnyDependency>> | DependencyReq<Extract<R, AnyDependency>>>
-> => op.use(...entries);
+  A extends readonly unknown[],
+  M,
+  const Entries extends readonly UseEntry[],
+>(
+  op: CoreOp<T, E, A, M>,
+  ...entries: ValidUseEntries<Entries, import("./internal.js").InferMetaReqs<M>>
+): CoreOp<T, E, A, ProvidedMeta<M, Entries>> => provideOp(op, entries);
 
 export const DI = Object.freeze({
-  Op,
   Dependency,
   require,
   singleton,
@@ -121,8 +92,8 @@ export const DI = Object.freeze({
   provide,
 });
 
-type OpLike<T, E, A extends readonly unknown[], R> = OgOp<T, E, A> | DI.Op<T, E, A, R>;
-export type InferErr<X> = X extends OpLike<infer _T, infer E, infer _A, infer _R> ? E : never;
-export type InferOk<X> = X extends OpLike<infer T, infer _E, infer _A, infer _R> ? T : never;
-export type InferArgs<X> = X extends OpLike<infer _T, infer _E, infer A, infer _R> ? A : never;
-export type InferReqs<X> = X extends DI.Op<infer _T, infer _E, infer _A, infer R> ? R : never;
+type OpLike<T, E, A extends readonly unknown[]> = CoreOp<T, E, A, any>;
+export type InferErr<X> = X extends OpLike<infer _T, infer E, infer _A> ? E : never;
+export type InferOk<X> = X extends OpLike<infer T, infer _E, infer _A> ? T : never;
+export type InferArgs<X> = X extends OpLike<infer _T, infer _E, infer A> ? A : never;
+export type InferReqs<X> = import("./internal.js").InferReqs<X>;

--- a/packages/std/src/di/index.ts
+++ b/packages/std/src/di/index.ts
@@ -1,5 +1,5 @@
 import { NEVER } from "@prodkit/op/internal";
-import type { Op as CoreOp } from "@prodkit/op";
+import type { Op } from "@prodkit/op";
 import {
   DI_TAG,
   DI_TOKEN,
@@ -11,9 +11,10 @@ import {
   type DependencyReq,
   type DependencyValue,
   type LazyBinding,
-  type ProvidedMeta,
   type UseEntry,
   type ValidUseEntries,
+  type InferMetaReqs,
+  ProvidedMeta,
 } from "./internal.js";
 
 export interface Dependency<T, Name extends string> {
@@ -79,9 +80,9 @@ export const provide = <
   M,
   const Entries extends readonly UseEntry[],
 >(
-  op: CoreOp<T, E, A, M>,
-  ...entries: ValidUseEntries<Entries, import("./internal.js").InferMetaReqs<M>>
-): CoreOp<T, E, A, ProvidedMeta<M, Entries>> => provideOp(op, entries);
+  op: Op<T, E, A, M>,
+  ...entries: ValidUseEntries<Entries, InferMetaReqs<M>>
+): Op<T, E, A, ProvidedMeta<M, Entries>> => provideOp(op, entries);
 
 export const DI = Object.freeze({
   Dependency,
@@ -91,8 +92,7 @@ export const DI = Object.freeze({
   provide,
 });
 
-type OpLike<T, E, A extends readonly unknown[]> = CoreOp<T, E, A, unknown>;
-export type InferErr<X> = X extends OpLike<infer _T, infer E, infer _A> ? E : never;
-export type InferOk<X> = X extends OpLike<infer T, infer _E, infer _A> ? T : never;
-export type InferArgs<X> = X extends OpLike<infer _T, infer _E, infer A> ? A : never;
-export type InferReqs<X> = import("./internal.js").InferReqs<X>;
+export type InferErr<X> = X extends Op<infer _T, infer E, infer _A> ? E : never;
+export type InferOk<X> = X extends Op<infer T, infer _E, infer _A> ? T : never;
+export type InferArgs<X> = X extends Op<infer _T, infer _E, infer A> ? A : never;
+export type { InferReqs } from "./internal.js";

--- a/packages/std/src/di/index.ts
+++ b/packages/std/src/di/index.ts
@@ -1,4 +1,3 @@
-// oxlint-disable typescript-eslint/no-explicit-any
 import { NEVER } from "@prodkit/op/internal";
 import type { Op as CoreOp } from "@prodkit/op";
 import {
@@ -38,14 +37,14 @@ export const Dependency = <const Name extends string>(key: Name): DependencyCtor
     static readonly [DI_TOKEN] = NEVER;
 
     static *[Symbol.iterator](): Generator<never, never, unknown> {
-      throw new TypeError("Use DI.require(dependency) to require a dependency binding");
+      throw new TypeError("Use DI.inject(dependency) to inject a dependency binding");
     }
   }
 
   return DependencyToken;
 };
 
-export const require = function* <C extends AnyDependency>(
+export const inject = function* <C extends AnyDependency>(
   dependency: C,
 ): Generator<
   DependencyReqInstruction<DependencyValue<C>, DependencyReq<C>>,
@@ -86,13 +85,13 @@ export const provide = <
 
 export const DI = Object.freeze({
   Dependency,
-  require,
+  inject,
   singleton,
   scoped,
   provide,
 });
 
-type OpLike<T, E, A extends readonly unknown[]> = CoreOp<T, E, A, any>;
+type OpLike<T, E, A extends readonly unknown[]> = CoreOp<T, E, A, unknown>;
 export type InferErr<X> = X extends OpLike<infer _T, infer E, infer _A> ? E : never;
 export type InferOk<X> = X extends OpLike<infer T, infer _E, infer _A> ? T : never;
 export type InferArgs<X> = X extends OpLike<infer _T, infer _E, infer A> ? A : never;

--- a/packages/std/src/di/index.types.test.ts
+++ b/packages/std/src/di/index.types.test.ts
@@ -1,16 +1,10 @@
 import { describe, expectTypeOf, test } from "vitest";
-import { Op, type EmptyMeta, type InferOpMeta } from "@prodkit/op";
-import {
-  NEEDS,
-  type ClearNeedsNamespace,
-  type IsRunnable,
-  type SetNeedsNamespace,
-} from "@prodkit/op/internal";
+import { Op, type EmptyMeta, type InferOpMeta, type Blocking } from "@prodkit/op";
+import { type IsRunnable } from "@prodkit/op/internal";
 import { DI, type Dependency } from "./index.js";
 import type {
   DependencyReq,
   DependencyValue,
-  DI_NEEDS_NAMESPACE,
   InferMetaReqs,
   InferReqs,
   ProvidedReq,
@@ -56,8 +50,7 @@ describe("DI cutover type contracts", () => {
 
     type _ = Assert<IsEqual<InferReqs<typeof op>, DatabaseDependency>>;
     type Meta = InferOpMeta<typeof op>;
-    type _Req = Assert<IsEqual<Meta["requirements"], DatabaseDependency>>;
-    type _Needs = Assert<IsEqual<Meta[typeof NEEDS], { readonly di: true }>>;
+    type _Req = Assert<IsEqual<Meta["requirements"], Blocking<DatabaseDependency>>>;
   });
 
   test("DI.inject contributes metadata on arity ops", () => {
@@ -68,8 +61,7 @@ describe("DI cutover type contracts", () => {
 
     type _Reqs = Assert<IsEqual<InferReqs<typeof findUser>, DatabaseDependency>>;
     type Meta = InferOpMeta<typeof findUser>;
-    type _Req = Assert<IsEqual<Meta["requirements"], DatabaseDependency>>;
-    type _Needs = Assert<IsEqual<Meta[typeof NEEDS], { readonly di: true }>>;
+    type _Req = Assert<IsEqual<Meta["requirements"], Blocking<DatabaseDependency>>>;
   });
 
   test("multiple and nested requirements infer as a union", () => {
@@ -105,6 +97,9 @@ describe("DI cutover type contracts", () => {
     );
 
     type _PartialReqs = Assert<IsEqual<InferReqs<typeof partial>, LoggerDependency>>;
+    type _PartialMeta = Assert<
+      IsEqual<InferOpMeta<typeof partial>["requirements"], Blocking<LoggerDependency>>
+    >;
     type _FullReqs = Assert<IsEqual<InferReqs<typeof full>, never>>;
   });
 
@@ -240,20 +235,13 @@ describe("DI cutover type contracts", () => {
     type _ = Assert<IsEqual<InferReqs<typeof runnable>, never>>;
   });
 
-  test("full DI provision clears only the di needs namespace", () => {
-    type WithAuth = SetNeedsNamespace<WithDIMeta<EmptyMeta, DatabaseDependency>, "auth">;
+  test("full DI provision clears requirements while other blocking keys remain", () => {
+    type WithAuth = WithDIMeta<EmptyMeta, DatabaseDependency> & { readonly auth: Blocking<true> };
     type _StillBlocked = Assert<IsEqual<IsRunnable<WithAuth>, false>>;
 
-    type ClearedDi = ClearNeedsNamespace<
-      Omit<WithDIMeta<EmptyMeta, never>, "requirements">,
-      typeof DI_NEEDS_NAMESPACE
-    >;
-    type _AuthRemains = Assert<
-      IsEqual<
-        ClearNeedsNamespace<WithAuth, typeof DI_NEEDS_NAMESPACE>[typeof NEEDS],
-        { readonly auth: true }
-      >
-    >;
-    type _DiOnly = Assert<IsEqual<ClearedDi, EmptyMeta>>;
+    type ClearedReqs = Omit<WithAuth, "requirements">;
+    type _AuthRemains = Assert<IsEqual<ClearedReqs["auth"], Blocking<true>>>;
+    type _RunnableAfterAuthOnly = Assert<IsEqual<IsRunnable<ClearedReqs>, false>>;
+    type _DiOnly = Assert<IsEqual<WithDIMeta<EmptyMeta, never>, EmptyMeta>>;
   });
 });

--- a/packages/std/src/di/index.types.test.ts
+++ b/packages/std/src/di/index.types.test.ts
@@ -1,0 +1,151 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { Op } from "@prodkit/op";
+import { DI, type Dependency } from "./index.js";
+import type {
+  DependencyReq,
+  DependencyValue,
+  InferMetaReqs,
+  InferReqs,
+  ProvidedReq,
+  UseReq,
+  WithDIMeta,
+} from "./internal.js";
+
+type Assert<T extends true> = T;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
+class DatabaseError extends Error {
+  readonly _tag = "DatabaseError";
+}
+
+interface User {
+  readonly id: string;
+}
+
+interface Database {
+  query: Op<User, DatabaseError, [sql: string, params: unknown[]]>;
+}
+
+class DatabaseDependency extends DI.Dependency("DatabaseDependency")<Database> {}
+class LoggerDependency extends DI.Dependency("LoggerDependency")<{
+  log: (message: string) => void;
+}> {}
+
+describe("DI cutover type contracts", () => {
+  test("plain non-DI ops have no requirements", () => {
+    const op = Op(function* () {
+      return 1;
+    });
+
+    type _ = Assert<IsEqual<InferReqs<typeof op>, never>>;
+  });
+
+  test("DI.require contributes requirements to plain Op", () => {
+    const op = Op(function* () {
+      const db = yield* DI.require(DatabaseDependency);
+      return yield* db.query("user", ["1"]);
+    });
+
+    type _ = Assert<IsEqual<InferReqs<typeof op>, DatabaseDependency>>;
+  });
+
+  test("multiple and nested requirements infer as a union", () => {
+    const findUser = Op(function* (id: string) {
+      const db = yield* DI.require(DatabaseDependency);
+      return yield* db.query("user", [id]);
+    });
+    const greet = Op(function* (id: string) {
+      const logger = yield* DI.require(LoggerDependency);
+      const user = yield* findUser(id);
+      logger.log(user.id);
+      return user.id;
+    });
+
+    expectTypeOf<InferReqs<typeof greet>>().toEqualTypeOf<DatabaseDependency | LoggerDependency>();
+  });
+
+  test("provisioning removes only satisfied requirements", () => {
+    const op = Op(function* () {
+      yield* DI.require(DatabaseDependency);
+      yield* DI.require(LoggerDependency);
+    });
+    const db = {
+      query: Op(function* (_sql: string, _params: unknown[]) {
+        return { id: "1" };
+      }).mapErr((error): DatabaseError => error),
+    } satisfies Database;
+
+    const partial = DI.provide(op, DI.singleton(DatabaseDependency, db));
+    const full = DI.provide(
+      partial,
+      DI.scoped(LoggerDependency, () => ({ log: () => {} })),
+    );
+
+    type _PartialReqs = Assert<IsEqual<InferReqs<typeof partial>, LoggerDependency>>;
+    type _FullReqs = Assert<IsEqual<InferReqs<typeof full>, never>>;
+  });
+
+  test("direct implementations satisfy matching dependency tokens only", () => {
+    class InMemoryDatabase extends DatabaseDependency implements Database {
+      query = Op(function* (_sql: string, params: unknown[]) {
+        return { id: String(params[0]) };
+      }).mapErr((error): DatabaseError => error);
+    }
+
+    const op = Op(function* () {
+      yield* DI.require(DatabaseDependency);
+      yield* DI.require(LoggerDependency);
+    });
+
+    const partial = DI.provide(op, new InMemoryDatabase());
+    type _ = Assert<IsEqual<InferReqs<typeof partial>, LoggerDependency>>;
+
+    // @ts-expect-error - unrelated dependency implementation cannot satisfy DatabaseDependency
+    DI.provide(op, { log: () => {} });
+  });
+
+  test("DI helper types expose the requirement math", () => {
+    const dbBinding = DI.singleton(DatabaseDependency, {
+      query: Op(function* (_sql: string, _params: unknown[]) {
+        return { id: "1" };
+      }).mapErr((error): DatabaseError => error),
+    });
+
+    type Req = DatabaseDependency | LoggerDependency;
+    type _EntryReq = Assert<IsEqual<UseReq<typeof dbBinding, Req>, DatabaseDependency>>;
+    type _Remaining = Assert<
+      IsEqual<ProvidedReq<readonly [typeof dbBinding], Req>, LoggerDependency>
+    >;
+    type _MetaReq = Assert<
+      IsEqual<InferMetaReqs<WithDIMeta<never, DatabaseDependency>>, DatabaseDependency>
+    >;
+    type _Value = Assert<IsEqual<DependencyValue<typeof DatabaseDependency>, Database>>;
+    type _Token = Assert<IsEqual<DependencyReq<typeof DatabaseDependency>, DatabaseDependency>>;
+
+    expectTypeOf(DatabaseDependency).toExtend<Dependency<Database, "DatabaseDependency">>();
+  });
+
+  test("metadata propagates through fluent combinators", () => {
+    const findUser = Op(function* (id: string) {
+      const db = yield* DI.require(DatabaseDependency);
+      return yield* db.query("user", [id]);
+    });
+    const log = Op(function* () {
+      const logger = yield* DI.require(LoggerDependency);
+      logger.log("ok");
+    });
+
+    const mapped = findUser.map((user) => user.id);
+    const timed = findUser.withTimeout(1);
+    const tapped = findUser("1").tap(() => log);
+    const flatMapped = findUser("1").flatMap(() => log);
+
+    expectTypeOf<InferReqs<typeof mapped>>().toEqualTypeOf<DatabaseDependency>();
+    expectTypeOf<InferReqs<typeof timed>>().toEqualTypeOf<DatabaseDependency>();
+    type _Tapped = Assert<IsEqual<InferReqs<typeof tapped>, DatabaseDependency | LoggerDependency>>;
+    type _FlatMapped = Assert<
+      IsEqual<InferReqs<typeof flatMapped>, DatabaseDependency | LoggerDependency>
+    >;
+  });
+});

--- a/packages/std/src/di/index.types.test.ts
+++ b/packages/std/src/di/index.types.test.ts
@@ -1,9 +1,16 @@
 import { describe, expectTypeOf, test } from "vitest";
-import { Op, type InferOpMeta } from "@prodkit/op";
+import { Op, type EmptyMeta, type InferOpMeta } from "@prodkit/op";
+import {
+  NEEDS,
+  type ClearNeedsNamespace,
+  type IsRunnable,
+  type SetNeedsNamespace,
+} from "@prodkit/op/internal";
 import { DI, type Dependency } from "./index.js";
 import type {
   DependencyReq,
   DependencyValue,
+  DI_NEEDS_NAMESPACE,
   InferMetaReqs,
   InferReqs,
   ProvidedReq,
@@ -48,12 +55,9 @@ describe("DI cutover type contracts", () => {
     });
 
     type _ = Assert<IsEqual<InferReqs<typeof op>, DatabaseDependency>>;
-    type _Meta = Assert<
-      IsEqual<
-        InferOpMeta<typeof op>,
-        WithDIMeta<import("@prodkit/op").EmptyMeta, DatabaseDependency>
-      >
-    >;
+    type Meta = InferOpMeta<typeof op>;
+    type _Req = Assert<IsEqual<Meta["requirements"], DatabaseDependency>>;
+    type _Needs = Assert<IsEqual<Meta[typeof NEEDS], { readonly di: true }>>;
   });
 
   test("DI.inject contributes metadata on arity ops", () => {
@@ -63,12 +67,9 @@ describe("DI cutover type contracts", () => {
     });
 
     type _Reqs = Assert<IsEqual<InferReqs<typeof findUser>, DatabaseDependency>>;
-    type _Meta = Assert<
-      IsEqual<
-        InferOpMeta<typeof findUser>,
-        WithDIMeta<import("@prodkit/op").EmptyMeta, DatabaseDependency>
-      >
-    >;
+    type Meta = InferOpMeta<typeof findUser>;
+    type _Req = Assert<IsEqual<Meta["requirements"], DatabaseDependency>>;
+    type _Needs = Assert<IsEqual<Meta[typeof NEEDS], { readonly di: true }>>;
   });
 
   test("multiple and nested requirements infer as a union", () => {
@@ -195,5 +196,64 @@ describe("DI cutover type contracts", () => {
     type _FlatMapped = Assert<
       IsEqual<InferReqs<typeof flatMapped>, DatabaseDependency | LoggerDependency>
     >;
+  });
+
+  test("unprovisioned ops cannot call .run()", () => {
+    const op = Op(function* () {
+      yield* DI.inject(DatabaseDependency);
+    });
+
+    // @ts-expect-error - not provisioned
+    op.run();
+  });
+
+  test("partially provisioned ops cannot call .run()", () => {
+    const op = Op(function* () {
+      yield* DI.inject(DatabaseDependency);
+      yield* DI.inject(LoggerDependency);
+    });
+    const db = {
+      query: Op(function* (_sql: string, _params: unknown[]) {
+        return { id: "1" };
+      }).mapErr((error): DatabaseError => error),
+    } satisfies Database;
+
+    const partial = DI.provide(op, DI.singleton(DatabaseDependency, db));
+
+    // @ts-expect-error - requirements remain
+    partial.run();
+  });
+
+  test("fully provisioned ops can call .run()", () => {
+    const op = Op(function* () {
+      yield* DI.inject(DatabaseDependency);
+    });
+    const db = {
+      query: Op(function* (_sql: string, _params: unknown[]) {
+        return { id: "1" };
+      }).mapErr((error): DatabaseError => error),
+    } satisfies Database;
+
+    const runnable = DI.provide(op, DI.singleton(DatabaseDependency, db));
+
+    expectTypeOf(runnable.run).toBeFunction();
+    type _ = Assert<IsEqual<InferReqs<typeof runnable>, never>>;
+  });
+
+  test("full DI provision clears only the di needs namespace", () => {
+    type WithAuth = SetNeedsNamespace<WithDIMeta<EmptyMeta, DatabaseDependency>, "auth">;
+    type _StillBlocked = Assert<IsEqual<IsRunnable<WithAuth>, false>>;
+
+    type ClearedDi = ClearNeedsNamespace<
+      Omit<WithDIMeta<EmptyMeta, never>, "requirements">,
+      typeof DI_NEEDS_NAMESPACE
+    >;
+    type _AuthRemains = Assert<
+      IsEqual<
+        ClearNeedsNamespace<WithAuth, typeof DI_NEEDS_NAMESPACE>[typeof NEEDS],
+        { readonly auth: true }
+      >
+    >;
+    type _DiOnly = Assert<IsEqual<ClearedDi, EmptyMeta>>;
   });
 });

--- a/packages/std/src/di/index.types.test.ts
+++ b/packages/std/src/di/index.types.test.ts
@@ -41,9 +41,9 @@ describe("DI cutover type contracts", () => {
     type _ = Assert<IsEqual<InferReqs<typeof op>, never>>;
   });
 
-  test("DI.require contributes requirements to plain Op", () => {
+  test("DI.inject contributes requirements to plain Op", () => {
     const op = Op(function* () {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", ["1"]);
     });
 
@@ -56,9 +56,9 @@ describe("DI cutover type contracts", () => {
     >;
   });
 
-  test("DI.require contributes metadata on arity ops", () => {
+  test("DI.inject contributes metadata on arity ops", () => {
     const findUser = Op(function* (id: string) {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", [id]);
     });
 
@@ -73,11 +73,11 @@ describe("DI cutover type contracts", () => {
 
   test("multiple and nested requirements infer as a union", () => {
     const findUser = Op(function* (id: string) {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", [id]);
     });
     const greet = Op(function* (id: string) {
-      const logger = yield* DI.require(LoggerDependency);
+      const logger = yield* DI.inject(LoggerDependency);
       const user = yield* findUser(id);
       logger.log(user.id);
       return user.id;
@@ -88,8 +88,8 @@ describe("DI cutover type contracts", () => {
 
   test("provisioning removes only satisfied requirements", () => {
     const op = Op(function* () {
-      yield* DI.require(DatabaseDependency);
-      yield* DI.require(LoggerDependency);
+      yield* DI.inject(DatabaseDependency);
+      yield* DI.inject(LoggerDependency);
     });
     const db = {
       query: Op(function* (_sql: string, _params: unknown[]) {
@@ -115,8 +115,8 @@ describe("DI cutover type contracts", () => {
     }
 
     const op = Op(function* () {
-      yield* DI.require(DatabaseDependency);
-      yield* DI.require(LoggerDependency);
+      yield* DI.inject(DatabaseDependency);
+      yield* DI.inject(LoggerDependency);
     });
 
     const partial = DI.provide(op, new InMemoryDatabase());
@@ -128,7 +128,7 @@ describe("DI cutover type contracts", () => {
 
   test("provide rejects bindings for dependencies the op does not require", () => {
     const dbOnly = Op(function* () {
-      yield* DI.require(DatabaseDependency);
+      yield* DI.inject(DatabaseDependency);
     });
     const db = {
       query: Op(function* (_sql: string, _params: unknown[]) {
@@ -175,11 +175,11 @@ describe("DI cutover type contracts", () => {
 
   test("metadata propagates through fluent combinators", () => {
     const findUser = Op(function* (id: string) {
-      const db = yield* DI.require(DatabaseDependency);
+      const db = yield* DI.inject(DatabaseDependency);
       return yield* db.query("user", [id]);
     });
     const log = Op(function* () {
-      const logger = yield* DI.require(LoggerDependency);
+      const logger = yield* DI.inject(LoggerDependency);
       logger.log("ok");
     });
 

--- a/packages/std/src/di/index.types.test.ts
+++ b/packages/std/src/di/index.types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, test } from "vitest";
-import { Op } from "@prodkit/op";
+import { Op, type InferOpMeta } from "@prodkit/op";
 import { DI, type Dependency } from "./index.js";
 import type {
   DependencyReq,
@@ -48,6 +48,27 @@ describe("DI cutover type contracts", () => {
     });
 
     type _ = Assert<IsEqual<InferReqs<typeof op>, DatabaseDependency>>;
+    type _Meta = Assert<
+      IsEqual<
+        InferOpMeta<typeof op>,
+        WithDIMeta<import("@prodkit/op").EmptyMeta, DatabaseDependency>
+      >
+    >;
+  });
+
+  test("DI.require contributes metadata on arity ops", () => {
+    const findUser = Op(function* (id: string) {
+      const db = yield* DI.require(DatabaseDependency);
+      return yield* db.query("user", [id]);
+    });
+
+    type _Reqs = Assert<IsEqual<InferReqs<typeof findUser>, DatabaseDependency>>;
+    type _Meta = Assert<
+      IsEqual<
+        InferOpMeta<typeof findUser>,
+        WithDIMeta<import("@prodkit/op").EmptyMeta, DatabaseDependency>
+      >
+    >;
   });
 
   test("multiple and nested requirements infer as a union", () => {
@@ -105,6 +126,32 @@ describe("DI cutover type contracts", () => {
     DI.provide(op, { log: () => {} });
   });
 
+  test("provide rejects bindings for dependencies the op does not require", () => {
+    const dbOnly = Op(function* () {
+      yield* DI.require(DatabaseDependency);
+    });
+    const db = {
+      query: Op(function* (_sql: string, _params: unknown[]) {
+        return { id: "1" };
+      }).mapErr((error): DatabaseError => error),
+    } satisfies Database;
+
+    DI.provide(
+      dbOnly,
+      // @ts-expect-error - LoggerDependency is not required by this op
+      DI.scoped(LoggerDependency, () => ({ log: () => {} })),
+    );
+
+    const satisfied = DI.provide(dbOnly, DI.singleton(DatabaseDependency, db));
+    type _Satisfied = Assert<IsEqual<InferReqs<typeof satisfied>, never>>;
+
+    DI.provide(
+      satisfied,
+      // @ts-expect-error - op has no remaining requirements
+      DI.scoped(LoggerDependency, () => ({ log: () => {} })),
+    );
+  });
+
   test("DI helper types expose the requirement math", () => {
     const dbBinding = DI.singleton(DatabaseDependency, {
       query: Op(function* (_sql: string, _params: unknown[]) {
@@ -143,6 +190,7 @@ describe("DI cutover type contracts", () => {
 
     expectTypeOf<InferReqs<typeof mapped>>().toEqualTypeOf<DatabaseDependency>();
     expectTypeOf<InferReqs<typeof timed>>().toEqualTypeOf<DatabaseDependency>();
+    type _TappedReqs = InferReqs<typeof tapped>;
     type _Tapped = Assert<IsEqual<InferReqs<typeof tapped>, DatabaseDependency | LoggerDependency>>;
     type _FlatMapped = Assert<
       IsEqual<InferReqs<typeof flatMapped>, DatabaseDependency | LoggerDependency>

--- a/packages/std/src/di/internal.ts
+++ b/packages/std/src/di/internal.ts
@@ -7,7 +7,10 @@ import {
   drive,
   unsafeCoerce,
   type CustomInstruction,
+  type NormalizeMeta,
   type RunContext,
+  type Simplify,
+  type StripEmpty,
 } from "@prodkit/op/internal";
 import { Op, type EmptyMeta } from "@prodkit/op";
 import type { Dependency } from "./index.js";
@@ -88,18 +91,6 @@ export type LazyBinding<C extends AnyDependency, V = unknown> = {
   readonly resolve: () => DependencyValue<C, V>;
 };
 export type AnyLazyBinding = LazyBinding<AnyDependency>;
-
-type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
-type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
-type NormalizeMeta<M> = [M] extends [never]
-  ? EmptyMeta
-  : M extends EmptyMeta
-    ? EmptyMeta
-    : M extends object
-      ? keyof M extends never
-        ? EmptyMeta
-        : M
-      : M;
 
 export type WithDIMeta<M, R> = Simplify<
   Omit<StripEmpty<M> & {}, "requirements"> & { readonly requirements: R }

--- a/packages/std/src/di/internal.ts
+++ b/packages/std/src/di/internal.ts
@@ -151,7 +151,6 @@ export type ProvidedMeta<M, Entries extends readonly UseEntry[]> = UpdateProvide
 
 export class DependencyReqInstruction<T, R> implements CustomInstruction<
   T,
-  never,
   WithDIMeta<EmptyMeta, R>
 > {
   readonly _tag = "DependencyReqInstruction";

--- a/packages/std/src/di/internal.ts
+++ b/packages/std/src/di/internal.ts
@@ -1,14 +1,16 @@
-import type { InferErr, Result, UnhandledException } from "better-result";
+// oxlint-disable typescript-eslint/no-explicit-any
 import {
-  Op,
-  TimeoutError,
-  type EnterContext,
-  type ExitContext,
-  type OpLifecycleHook,
-  type RetryPolicy,
-} from "@prodkit/op";
-import { hasBrand, NEVER, unsafeCoerce, type AbortSignalLike } from "@prodkit/op/internal";
-import type { Dependency, DI } from "./index.js";
+  CUSTOM_INSTRUCTION_META,
+  NEVER,
+  SuspendInstruction,
+  createRunContext,
+  drive,
+  unsafeCoerce,
+  type CustomInstruction,
+  type RunContext,
+} from "@prodkit/op/internal";
+import { Op, type EmptyMeta } from "@prodkit/op";
+import type { Dependency } from "./index.js";
 
 declare global {
   interface ObjectConstructor {
@@ -23,6 +25,7 @@ export class MissingDependencyError extends Error {
   override readonly name = "MissingDependencyError";
   readonly _tag = "MissingDependencyError";
   readonly key: string;
+
   constructor(key: string) {
     super(`${key} is required but was not provided`);
     this.key = key;
@@ -33,14 +36,36 @@ export class MissingDependencyError extends Error {
   }
 }
 
-export type RunResult<T, E> = Promise<Result<T, E | UnhandledException>>;
+export class AlreadyProvidedError extends Error {
+  override readonly name = "AlreadyProvidedError";
+  readonly _tag = "AlreadyProvidedError";
+  readonly key: string;
+
+  constructor(key: string) {
+    super(`${key} was already provided`);
+    this.key = key;
+  }
+
+  static is(value: unknown): value is AlreadyProvidedError {
+    return value instanceof AlreadyProvidedError;
+  }
+}
 
 export const DI_TOKEN = Symbol("prodkit.std.di.dependency");
-const DI_REQ_TOKEN = Symbol("prodkit.std.di.req");
-const DI_OP_TOKEN = Symbol("prodkit.std.di.op");
 export const DI_TAG = "DI";
 
+const DI_ENV_EXTENSION = Symbol("prodkit.std.di.env");
+const MISSING_DEPENDENCY = Symbol("prodkit.std.di.missing-dependency");
+
 export type AnyDependency = Dependency<unknown, string>;
+
+export interface DependencyCtor<Name extends string> {
+  readonly _tag: typeof DI_TAG;
+  readonly key: Name;
+  readonly [DI_TOKEN]: never;
+
+  new <T>(): Dependency<T, Name>;
+}
 
 export type DependencyValue<C, V = unknown> = C extends abstract new (
   ...args: never[]
@@ -56,6 +81,7 @@ export type Binding<C extends AnyDependency, V = unknown> = {
   readonly value: DependencyValue<C, V>;
 };
 export type AnyBinding = Binding<AnyDependency>;
+
 export type LazyBinding<C extends AnyDependency, V = unknown> = {
   readonly _tag: "DependencyLazyBinding";
   readonly dependency: C;
@@ -63,22 +89,90 @@ export type LazyBinding<C extends AnyDependency, V = unknown> = {
 };
 export type AnyLazyBinding = LazyBinding<AnyDependency>;
 
-export type InferReqs<C> = C extends DI.Op<infer _T, infer _E, infer _A, infer R> ? R : never;
-type InferName<C> = C extends Dependency<infer _T, infer Name> ? Name : never;
+type StripEmpty<M> = [M] extends [never] ? {} : M extends EmptyMeta ? {} : M;
+type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T;
+type NormalizeMeta<M> = [M] extends [never]
+  ? EmptyMeta
+  : M extends EmptyMeta
+    ? EmptyMeta
+    : M extends object
+      ? keyof M extends never
+        ? EmptyMeta
+        : M
+      : M;
 
-/** Yielded by `DI.require` and bare dependency classes to ask the runtime for a dependency binding. */
-export class DependencyReqInstruction<T, R> {
+export type WithDIMeta<M, R> = Simplify<
+  Omit<StripEmpty<M> & {}, "requirements"> & { readonly requirements: R }
+>;
+
+export type InferMetaReqs<M> = M extends { readonly requirements: infer R } ? R : never;
+
+export type InferReqs<C> = C extends Op<any, any, infer _A, infer M> ? InferMetaReqs<M> : never;
+
+export type DependencyReq<C> = C extends { readonly prototype: infer I } ? I : C;
+
+type SatisfiedDirectReq<P, R> = R extends unknown ? (P extends R ? R : never) : never;
+
+export type UseEntry = AnyBinding | AnyLazyBinding | AnyDependency;
+
+export type UseReq<P, R = unknown> =
+  P extends Binding<infer C>
+    ? DependencyReq<C>
+    : P extends LazyBinding<infer C>
+      ? DependencyReq<C>
+      : P extends AnyDependency
+        ? SatisfiedDirectReq<P, R>
+        : never;
+
+export type ProvidedReq<Entries extends readonly UseEntry[], R> = Exclude<
+  R,
+  UseReq<Entries[number], R>
+>;
+
+type InvalidUseReq<Entries extends readonly UseEntry[], R> = Exclude<UseReq<Entries[number], R>, R>;
+
+export type ValidUseEntries<Entries extends readonly UseEntry[], R> = [
+  InvalidUseReq<Entries, R>,
+] extends [never]
+  ? Entries
+  : never;
+
+type UpdateProvidedMeta<M, R> = NormalizeMeta<
+  Simplify<
+    Omit<StripEmpty<M> & {}, "requirements"> &
+      ([R] extends [never] ? {} : { readonly requirements: R })
+  >
+>;
+
+export type ProvidedMeta<M, Entries extends readonly UseEntry[]> = UpdateProvidedMeta<
+  M,
+  ProvidedReq<Entries, InferMetaReqs<M>>
+>;
+
+export class DependencyReqInstruction<T, R> implements CustomInstruction<
+  T,
+  never,
+  WithDIMeta<EmptyMeta, R>
+> {
   readonly _tag = "DependencyReqInstruction";
-  readonly [DI_REQ_TOKEN]: { _T: T; _R: R } = NEVER;
+  readonly [CUSTOM_INSTRUCTION_META]: WithDIMeta<EmptyMeta, R> = NEVER;
   readonly dependency: AnyDependency;
 
   constructor(dependency: AnyDependency) {
     this.dependency = dependency;
   }
 
-  // oxlint-disable-next-line typescript/no-explicit-any
-  *[Symbol.iterator](): Generator<this, any, unknown> {
-    return yield this;
+  resolve(context: RunContext<readonly unknown[]>): T {
+    const env = readEnv(context);
+    const value = resolveDependencyValue(env, this.dependency);
+    if (value === MISSING_DEPENDENCY) {
+      throw new MissingDependencyError(this.dependency.key);
+    }
+    return unsafeCoerce<T>(value);
+  }
+
+  *[Symbol.iterator](): Generator<this, T, unknown> {
+    return (yield this) as T;
   }
 
   static is(value: unknown): value is DependencyReqInstruction<unknown, AnyDependency> {
@@ -86,175 +180,7 @@ export class DependencyReqInstruction<T, R> {
   }
 }
 
-export type ConditionalIterable<T, E, A extends readonly unknown[], R> = A extends []
-  ? { [Symbol.iterator](): Generator<EmbedDiOpInstruction<T, E, R>, T, unknown> }
-  : {};
-
-export interface DependencyCtor<Name extends string> {
-  readonly _tag: typeof DI_TAG;
-  readonly key: Name;
-  readonly [DI_TOKEN]: never;
-
-  new <T>(): Dependency<T, Name>;
-}
-
-/** Constructor-or-token metatype used in dependency-req set `R` for a dependency key class. */
-export type DependencyReq<C> = C extends abstract new (...args: never[]) => infer I ? I : C;
-
-/** Yield wrapping a nested nullary `DI.Op` so the parent generator can `yield*` it. */
-export class EmbedDiOpInstruction<T, E, R> {
-  readonly _tag = "EmbedDiOpInstruction";
-  readonly op: DI.Op<T, E, [], R>;
-
-  constructor(op: DI.Op<T, E, [], R>) {
-    this.op = op;
-  }
-
-  // oxlint-disable-next-line typescript/no-explicit-any
-  *[Symbol.iterator](): Generator<this, any, unknown> {
-    return yield this;
-  }
-}
-
-export type BindingReq<P> = P extends Binding<infer C> ? DependencyReq<C> : never;
-export type LazyBindingReq<P> = P extends LazyBinding<infer C> ? DependencyReq<C> : never;
-type SatisfiedReq<P, R> = R extends unknown ? (P extends R ? R : never) : never;
-export type UseEntry = AnyBinding | AnyLazyBinding | AnyDependency;
-export type UseReq<P, R> =
-  P extends Binding<infer C>
-    ? DependencyReq<C>
-    : P extends LazyBinding<infer C>
-      ? DependencyReq<C>
-      : P extends AnyDependency
-        ? SatisfiedReq<P, R>
-        : never;
-
-export type AnyNullaryDiOp = DI.Op<unknown, unknown, [], unknown>;
-export type AnyDiOp = DI.Op<unknown, unknown, readonly unknown[], unknown>;
-export type AnyNullaryOp = Op<unknown, unknown, []>;
-export type Env = ReadonlyMap<AnyDependency, unknown>;
-
-export type InferYieldReq<Y> =
-  | (Y extends DependencyReqInstruction<unknown, infer R> ? R : never)
-  | (Y extends EmbedDiOpInstruction<unknown, unknown, infer R> ? R : never);
-export type DistributeReq<R> = R extends unknown ? R : never;
-
-export type InferEmbedErr<Y> =
-  Y extends EmbedDiOpInstruction<unknown, infer E, unknown> ? E : never;
-
-export type OpLike<T, E> = Op<T, E, []> | DI.Op<T, E, [], unknown>;
-
-export type ObserverReq<X> = X extends DI.Op<unknown, unknown, [], infer R> ? R : never;
-export type ObserverErr<X> = X extends OpLike<unknown, infer E> ? E : never;
-export type ObserverOk<X> = X extends OpLike<infer T, unknown> ? T : Awaited<X>;
-
-export interface DiOpBase<T, E, A extends readonly unknown[], R> {
-  readonly _tag: "DiOp";
-  readonly [DI_OP_TOKEN]: true;
-
-  (...args: A): DI.Op<T, E, [], R>;
-
-  /** Runs a fully-provided wrapper with the same argument shape as the wrapped `Op`. */
-  readonly run: [R] extends [never]
-    ? (...args: A) => Promise<Result<T, E | UnhandledException>>
-    : never;
-
-  /** Applies dependency bindings and removes them from the remaining req type. */
-  use<
-    const Entries extends ReadonlyArray<
-      | Binding<Extract<R, AnyDependency>, DependencyValue<Extract<R, AnyDependency>>>
-      | LazyBinding<Extract<R, AnyDependency>, DependencyValue<Extract<R, AnyDependency>>>
-    >,
-  >(
-    ...entries:
-      | Entries
-      | Dependency<
-          DependencyValue<Extract<R, AnyDependency>>,
-          InferName<Extract<R, AnyDependency>>
-        >[]
-  ): DI.Op<T, E, A, Exclude<R, UseReq<Entries[number], R>>>;
-
-  withRetry(policy?: RetryPolicy): DI.Op<T, E, A, R>;
-  withTimeout(timeoutMs: number): DI.Op<T, E | TimeoutError, A, R>;
-  withSignal(signal: AbortSignalLike): DI.Op<T, E, A, R>;
-  withRelease(release: (value: T) => unknown): DI.Op<T, E, A, R>;
-
-  on(event: "enter", initialize: (ctx: EnterContext<A>) => unknown): DI.Op<T, E, A, R>;
-  on(event: "exit", finalize: (ctx: ExitContext<T, E, A>) => unknown): DI.Op<T, E, A, R>;
-
-  map<U>(transform: (value: T) => U): DI.Op<Awaited<U>, E, A, R>;
-  mapErr<E2>(transform: (error: E) => E2): DI.Op<T, E2, A, R>;
-
-  flatMap<U, E2, R2>(bind: (value: T) => DI.Op<U, E2, [], R2>): DI.Op<U, E | E2, A, R | R2>;
-  flatMap<U, E2>(bind: (value: T) => Op<U, E2, []>): DI.Op<U, E | E2, A, R>;
-
-  tap<RObserved>(
-    observe: (value: T) => RObserved,
-  ): DI.Op<T, E | ObserverErr<RObserved>, A, R | ObserverReq<RObserved>>;
-  tapErr<RObserved>(
-    observe: (error: E) => RObserved,
-  ): DI.Op<T, E | ObserverErr<RObserved>, A, R | ObserverReq<RObserved>>;
-
-  recover<ECaught extends E, RRecovered>(
-    predicate: (error: E) => error is ECaught,
-    handler: (error: ECaught) => RRecovered,
-  ): DI.Op<
-    T | ObserverOk<RRecovered>,
-    Exclude<E, ECaught> | ObserverErr<RRecovered>,
-    A,
-    R | ObserverReq<RRecovered>
-  >;
-  recover<RRecovered>(
-    predicate: (error: E) => boolean,
-    handler: (error: E) => RRecovered,
-  ): DI.Op<T | ObserverOk<RRecovered>, E | ObserverErr<RRecovered>, A, R | ObserverReq<RRecovered>>;
-}
-
-export interface DiOpState<T, E, A extends readonly unknown[]> {
-  readonly buildOp: (env: Env) => Op<T, E, A>;
-  readonly env: Env;
-  readonly iterable: boolean;
-}
-
-export interface DiOpRuntime<T, E, A extends readonly unknown[]> {
-  toOp(env?: Env): Op<T, E, A>;
-}
-
-export type DiOpCallable<T, E, A extends readonly unknown[], R> = ((
-  ...args: A
-) => DI.Op<T, E, [], R>) &
-  DiOpRuntime<T, E, A> & {
-    readonly _tag: "DiOp";
-    readonly [DI_OP_TOKEN]: true;
-    readonly run: (...args: A) => RunResult<T, E>;
-    readonly use: (...entries: readonly UseEntry[]) => DI.Op<T, E, A, unknown>;
-    readonly withRetry: (policy?: RetryPolicy) => DI.Op<T, E, A, R>;
-    readonly withTimeout: (timeoutMs: number) => DI.Op<T, E | TimeoutError, A, R>;
-    readonly withSignal: (signal: AbortSignalLike) => DI.Op<T, E, A, R>;
-    readonly withRelease: (release: (value: T) => unknown) => DI.Op<T, E, A, R>;
-    readonly on: (event: OpLifecycleHook, handler: unknown) => DI.Op<T, E, A, R>;
-    readonly map: (transform: (value: T) => unknown) => DI.Op<unknown, E, A, R>;
-    readonly mapErr: (transform: (error: E) => unknown) => DI.Op<T, unknown, A, R>;
-    readonly flatMap: (
-      bind: (value: T) => OpLike<unknown, unknown>,
-    ) => DI.Op<unknown, unknown, A, R>;
-    readonly tap: (observe: (value: T) => unknown) => DI.Op<T, unknown, A, R>;
-    readonly tapErr: (observe: (error: E) => unknown) => DI.Op<T, unknown, A, R>;
-    readonly recover: (
-      predicate: (error: E) => boolean,
-      handler: (error: E) => unknown,
-    ) => DI.Op<unknown, unknown, A, R>;
-  };
-
-function isEmbeddedDependencyOperationInstruction(
-  value: unknown,
-): value is EmbedDiOpInstruction<unknown, unknown, unknown> {
-  return value instanceof EmbedDiOpInstruction;
-}
-
-function isDependencyOperation(value: unknown): value is AnyDiOp {
-  return hasBrand(value, DI_OP_TOKEN);
-}
+type Env = Map<AnyDependency, unknown>;
 
 function isDependencyBinding(value: unknown): value is AnyBinding {
   return (
@@ -294,10 +220,23 @@ function dependencyTokenFromEntry(entry: AnyDependency): AnyDependency {
   return entry;
 }
 
+function sameDependencyKey(a: AnyDependency, b: AnyDependency): boolean {
+  return a === b || a.key === b.key;
+}
+
+function findProvidedToken(env: Env, dependency: AnyDependency): AnyDependency | undefined {
+  for (const token of env.keys()) {
+    if (sameDependencyKey(token, dependency)) return token;
+  }
+  return undefined;
+}
+
 function withDependencyBinding(env: Env, dependency: AnyDependency, value: unknown): Env {
-  const nextEnv = new Map(env);
-  nextEnv.set(dependency, value);
-  return nextEnv;
+  if (findProvidedToken(env, dependency) !== undefined) {
+    throw new AlreadyProvidedError(dependency.key);
+  }
+  env.set(dependency, value);
+  return env;
 }
 
 function withDependencyEntry(env: Env, entry: UseEntry): Env {
@@ -310,201 +249,55 @@ function withDependencyEntry(env: Env, entry: UseEntry): Env {
   return withDependencyBinding(env, dependencyTokenFromEntry(entry), entry);
 }
 
-const MISSING_DEPENDENCY = Symbol("prodkit.std.di.missing-dependency");
+function readEnv(context: RunContext<readonly unknown[]>): Env {
+  const env = context.extensions.get(DI_ENV_EXTENSION);
+  if (env instanceof Map) return unsafeCoerce<Env>(env);
+  return new Map();
+}
 
 function resolveDependencyValue(env: Env, dependency: AnyDependency): unknown {
-  let matchedToken: AnyDependency | undefined;
-  let matchedValue: unknown = MISSING_DEPENDENCY;
+  const matchedToken = findProvidedToken(env, dependency);
+  if (matchedToken === undefined) return MISSING_DEPENDENCY;
 
-  if (env.has(dependency)) {
-    matchedToken = dependency;
-    matchedValue = env.get(dependency);
-  } else {
-    for (const [token, value] of env.entries()) {
-      if (token.key === dependency.key) {
-        matchedToken = token;
-        matchedValue = value;
-        break;
-      }
-    }
-  }
-
-  if (matchedValue === MISSING_DEPENDENCY) {
-    return MISSING_DEPENDENCY;
-  }
+  const matchedValue = env.get(matchedToken);
 
   if (isDependencyLazyBinding(matchedValue)) {
     const resolved = matchedValue.resolve();
-    if (matchedToken !== undefined && env instanceof Map) {
-      env.set(matchedToken, resolved);
-    }
+    env.set(matchedToken, resolved);
     return resolved;
   }
 
   return matchedValue;
 }
 
-function toRuntimeOp<T, E, A extends readonly unknown[]>(
-  value: DI.Op<T, E, A, unknown>,
-  env: Env,
-): Op<T, E, A> {
-  return unsafeCoerce<DiOpRuntime<T, E, A>>(value).toOp(env);
-}
-
-function toRuntimeNullaryOp(value: AnyDiOp, env: Env): AnyNullaryOp {
-  return toRuntimeOp(unsafeCoerce<AnyNullaryDiOp>(value), env);
-}
-
-function materializeDependencyAwareReturn(value: unknown, env: Env): unknown {
-  if (!isDependencyOperation(value)) return value;
-  return toRuntimeNullaryOp(value, env);
-}
-
-function runWithState<T, E, A extends readonly unknown[]>(
-  state: DiOpState<T, E, A>,
-  args: A,
-): RunResult<T, E> {
-  return state.buildOp(new Map(state.env)).run(...args);
-}
-
-function invokeWithState<T, E, A extends readonly unknown[]>(
-  state: DiOpState<T, E, A>,
-  env: Env,
-  args: A,
-): Op<T, E, []> {
-  return state.buildOp(new Map(env))(...args);
-}
-
-function recreateDependencyOp<T, E, A extends readonly unknown[], R>(
-  state: DiOpState<T, E, A>,
-): DI.Op<T, E, A, R> {
-  return createDependencyOp<T, E, A, R>(state);
-}
-
-function mapDependencyOp<T, E, A extends readonly unknown[], R, TOut, EOut>(
-  state: DiOpState<T, E, A>,
-  mapOp: (op: Op<T, E, A>, env: Env) => Op<TOut, EOut, A>,
-): DI.Op<TOut, EOut, A, R> {
-  return recreateDependencyOp<TOut, EOut, A, R>({
-    ...state,
-    buildOp: (env) => mapOp(state.buildOp(env), env),
-  });
-}
-
-function applyUseEntries<T, E, A extends readonly unknown[], R>(
-  state: DiOpState<T, E, A>,
+function extendContext(
+  context: RunContext<readonly unknown[]>,
   entries: readonly UseEntry[],
-): DI.Op<T, E, A, R> {
-  return recreateDependencyOp<T, E, A, R>({
-    ...state,
-    env: entries.reduce((env, entry) => withDependencyEntry(env, entry), state.env),
+): RunContext<readonly unknown[]> {
+  const parentEnv = readEnv(context);
+  const env = entries.reduce(
+    (current, entry) => withDependencyEntry(current, entry),
+    new Map(parentEnv),
+  );
+  const extensions = new Map(context.extensions);
+  extensions.set(DI_ENV_EXTENSION, env);
+  return createRunContext(context.signal, context.args, extensions);
+}
+
+export function provideOp<
+  T,
+  E,
+  A extends readonly unknown[],
+  M,
+  const Entries extends readonly UseEntry[],
+>(op: Op<T, E, A, M>, entries: Entries): Op<T, E, A, ProvidedMeta<M, Entries>> {
+  const provided = Op(function* (...args: A) {
+    const result = yield* new SuspendInstruction((context) =>
+      drive(op(...args), extendContext(context, entries)),
+    );
+    if (result.isErr()) return yield* result;
+    return result.value;
   });
-}
 
-function asDiOp<T, E, A extends readonly unknown[], R>(
-  value: DiOpCallable<T, E, A, R>,
-): DI.Op<T, E, A, R> {
-  return unsafeCoerce<DI.Op<T, E, A, R>>(value);
-}
-
-function buildIterableFacade<T, E, R>(
-  self: DiOpCallable<T, E, [], R>,
-): {
-  [Symbol.iterator](): Generator<EmbedDiOpInstruction<T, E, R>, T, unknown>;
-} {
-  return {
-    [Symbol.iterator]: function* (): Generator<EmbedDiOpInstruction<T, E, R>, T, unknown> {
-      return yield* new EmbedDiOpInstruction(asDiOp<T, E, [], R>(self));
-    },
-  };
-}
-
-function toFlatMapOpLike(value: OpLike<unknown, unknown>, env: Env): AnyNullaryOp {
-  return isDependencyOperation(value) ? toRuntimeNullaryOp(value, env) : value;
-}
-
-export function createDependencyOp<T, E, A extends readonly unknown[], R>(
-  state: DiOpState<T, E, A>,
-): DI.Op<T, E, A, R> {
-  const lift = <TOut, EOut>(
-    mapOp: (op: Op<T, E, A>, env: Env) => Op<TOut, EOut, A>,
-  ): DI.Op<TOut, EOut, A, R> => mapDependencyOp(state, mapOp);
-
-  const self: DiOpCallable<T, E, A, R> = Object.assign(
-    (...args: A) =>
-      recreateDependencyOp<T, E, [], R>({
-        buildOp: (env) => invokeWithState(state, env, args),
-        env: state.env,
-        iterable: true,
-      }),
-    {
-      _tag: "DiOp" as const,
-      [DI_OP_TOKEN]: true as const,
-      toOp: (envOverride?: Env) => state.buildOp(new Map(envOverride ?? state.env)),
-      run: (...args: A) => runWithState(state, args),
-      use: (...entries: readonly UseEntry[]) => applyUseEntries(state, entries),
-      withRetry: (policy?: RetryPolicy) => lift((op) => op.withRetry(policy)),
-      withTimeout: (timeoutMs: number) => lift((op) => op.withTimeout(timeoutMs)),
-      withSignal: (signal: AbortSignalLike) => lift((op) => op.withSignal(signal)),
-      withRelease: (release: (value: T) => unknown) => lift((op) => op.withRelease(release)),
-      on: (event: OpLifecycleHook, handler: unknown) =>
-        lift((op) => op.on(event as "enter", handler as never)),
-      map: (transform: (value: T) => unknown) => lift((op) => op.map(transform)),
-      mapErr: (transform: (error: E) => unknown) => lift((op) => op.mapErr(transform)),
-      flatMap: (bind: (value: T) => OpLike<unknown, unknown>) =>
-        lift((op, env) => op.flatMap((value) => toFlatMapOpLike(bind(value), env))),
-      tap: (observe: (value: T) => unknown) =>
-        lift((op, env) => op.tap((value) => materializeDependencyAwareReturn(observe(value), env))),
-      tapErr: (observe: (error: E) => unknown) =>
-        lift((op, env) =>
-          op.tapErr((error) => materializeDependencyAwareReturn(observe(error), env)),
-        ),
-      recover: (predicate: (error: E) => boolean, handler: (error: E) => unknown) =>
-        lift((op, env) =>
-          op.recover(predicate, (error) => materializeDependencyAwareReturn(handler(error), env)),
-        ),
-    },
-  );
-
-  if (state.iterable) {
-    Object.assign(self, buildIterableFacade(unsafeCoerce<DiOpCallable<T, E, [], R>>(self)));
-  }
-
-  return asDiOp(self);
-}
-
-export function buildDependencyOp<Y, T, A extends readonly unknown[]>(
-  program: (...args: A) => Generator<Y, T, unknown>,
-  env: Env,
-): Op<T, InferErr<Y> | InferEmbedErr<Y>, A> {
-  return unsafeCoerce(
-    Op(function* (...args: A) {
-      const iterator = program(...args);
-      let input: unknown;
-
-      while (true) {
-        const step = iterator.next(input);
-        if (step.done) return step.value;
-
-        const stepValue = step.value;
-
-        if (DependencyReqInstruction.is(stepValue)) {
-          const value = resolveDependencyValue(env, stepValue.dependency);
-          if (value !== MISSING_DEPENDENCY) {
-            input = value;
-            continue;
-          }
-
-          throw new MissingDependencyError(stepValue.dependency.key);
-        }
-
-        if (isEmbeddedDependencyOperationInstruction(stepValue)) {
-          input = yield* toRuntimeOp(stepValue.op, env);
-          continue;
-        }
-
-        input = yield stepValue as never;
-      }
-    }),
-  );
+  return unsafeCoerce<Op<T, E, A, ProvidedMeta<M, Entries>>>(provided);
 }

--- a/packages/std/src/di/internal.ts
+++ b/packages/std/src/di/internal.ts
@@ -1,4 +1,3 @@
-// oxlint-disable typescript-eslint/no-explicit-any
 import {
   CUSTOM_INSTRUCTION_META,
   NEVER,
@@ -98,7 +97,8 @@ export type WithDIMeta<M, R> = Simplify<
 
 export type InferMetaReqs<M> = M extends { readonly requirements: infer R } ? R : never;
 
-export type InferReqs<C> = C extends Op<any, any, infer _A, infer M> ? InferMetaReqs<M> : never;
+export type InferReqs<C> =
+  C extends Op<unknown, unknown, infer _A, infer M> ? InferMetaReqs<M> : never;
 
 export type DependencyReq<C> = C extends { readonly prototype: infer I } ? I : C;
 

--- a/packages/std/src/di/internal.ts
+++ b/packages/std/src/di/internal.ts
@@ -7,10 +7,9 @@ import {
   unsafeCoerce,
   hasOwn,
   type CustomInstruction,
-  type ClearNeedsNamespace,
-  type NeedsLatchMeta,
+  type Blocking,
+  type NormalizeMeta,
   type RunContext,
-  type SetNeedsNamespace,
   type Simplify,
   type StripEmpty,
 } from "@prodkit/op/internal";
@@ -84,15 +83,11 @@ export type LazyBinding<C extends AnyDependency, V = unknown> = {
 };
 export type AnyLazyBinding = LazyBinding<AnyDependency>;
 
-export const DI_NEEDS_NAMESPACE = "di" as const;
+export type WithDIMeta<M, R> = [R] extends [never]
+  ? NormalizeMeta<Omit<StripEmpty<M>, "requirements">>
+  : Simplify<Omit<StripEmpty<M>, "requirements"> & { readonly requirements: Blocking<R> }>;
 
-export type WithDIMeta<M, R> = Simplify<
-  NeedsLatchMeta<Omit<StripEmpty<M> & {}, "requirements">, typeof DI_NEEDS_NAMESPACE> & {
-    readonly requirements: R;
-  }
->;
-
-export type InferMetaReqs<M> = M extends { readonly requirements: infer R } ? R : never;
+export type InferMetaReqs<M> = M extends { readonly requirements: Blocking<infer R> } ? R : never;
 
 export type InferReqs<C> =
   C extends Op<unknown, unknown, infer _A, infer M> ? InferMetaReqs<M> : never;
@@ -126,11 +121,8 @@ export type ValidUseEntries<Entries extends readonly UseEntry[], R> = [
   : never;
 
 type UpdateProvidedMeta<M, R> = [R] extends [never]
-  ? ClearNeedsNamespace<Omit<StripEmpty<M> & {}, "requirements">, typeof DI_NEEDS_NAMESPACE>
-  : SetNeedsNamespace<
-      Simplify<Omit<StripEmpty<M> & {}, "requirements"> & { readonly requirements: R }>,
-      typeof DI_NEEDS_NAMESPACE
-    >;
+  ? NormalizeMeta<Omit<StripEmpty<M>, "requirements">>
+  : Simplify<Omit<StripEmpty<M>, "requirements"> & { readonly requirements: Blocking<R> }>;
 
 export type ProvidedMeta<M, Entries extends readonly UseEntry[]> = UpdateProvidedMeta<
   M,

--- a/packages/std/src/di/internal.ts
+++ b/packages/std/src/di/internal.ts
@@ -5,24 +5,17 @@ import {
   createRunContext,
   drive,
   unsafeCoerce,
+  hasOwn,
   type CustomInstruction,
-  type NormalizeMeta,
+  type ClearNeedsNamespace,
+  type NeedsLatchMeta,
   type RunContext,
+  type SetNeedsNamespace,
   type Simplify,
   type StripEmpty,
 } from "@prodkit/op/internal";
 import { Op, type EmptyMeta } from "@prodkit/op";
 import type { Dependency } from "./index.js";
-
-declare global {
-  interface ObjectConstructor {
-    hasOwn<T extends object, K extends PropertyKey>(
-      object: T,
-      key: K,
-    ): object is T & Record<K, unknown>;
-  }
-}
-
 export class MissingDependencyError extends Error {
   override readonly name = "MissingDependencyError";
   readonly _tag = "MissingDependencyError";
@@ -91,8 +84,12 @@ export type LazyBinding<C extends AnyDependency, V = unknown> = {
 };
 export type AnyLazyBinding = LazyBinding<AnyDependency>;
 
+export const DI_NEEDS_NAMESPACE = "di" as const;
+
 export type WithDIMeta<M, R> = Simplify<
-  Omit<StripEmpty<M> & {}, "requirements"> & { readonly requirements: R }
+  NeedsLatchMeta<Omit<StripEmpty<M> & {}, "requirements">, typeof DI_NEEDS_NAMESPACE> & {
+    readonly requirements: R;
+  }
 >;
 
 export type InferMetaReqs<M> = M extends { readonly requirements: infer R } ? R : never;
@@ -128,12 +125,12 @@ export type ValidUseEntries<Entries extends readonly UseEntry[], R> = [
   ? Entries
   : never;
 
-type UpdateProvidedMeta<M, R> = NormalizeMeta<
-  Simplify<
-    Omit<StripEmpty<M> & {}, "requirements"> &
-      ([R] extends [never] ? {} : { readonly requirements: R })
-  >
->;
+type UpdateProvidedMeta<M, R> = [R] extends [never]
+  ? ClearNeedsNamespace<Omit<StripEmpty<M> & {}, "requirements">, typeof DI_NEEDS_NAMESPACE>
+  : SetNeedsNamespace<
+      Simplify<Omit<StripEmpty<M> & {}, "requirements"> & { readonly requirements: R }>,
+      typeof DI_NEEDS_NAMESPACE
+    >;
 
 export type ProvidedMeta<M, Entries extends readonly UseEntry[]> = UpdateProvidedMeta<
   M,
@@ -176,7 +173,7 @@ function isDependencyBinding(value: unknown): value is AnyBinding {
   return (
     typeof value === "object" &&
     value !== null &&
-    Object.hasOwn(value, "_tag") &&
+    hasOwn(value, "_tag") &&
     value._tag === "DependencyBinding"
   );
 }
@@ -185,7 +182,7 @@ function isDependencyLazyBinding(value: unknown): value is AnyLazyBinding {
   return (
     typeof value === "object" &&
     value !== null &&
-    Object.hasOwn(value, "_tag") &&
+    hasOwn(value, "_tag") &&
     value._tag === "DependencyLazyBinding"
   );
 }
@@ -197,10 +194,10 @@ function dependencyTokenFromEntry(entry: AnyDependency): AnyDependency {
   let current: unknown = ctor;
   while (typeof current === "function") {
     if (
-      Object.hasOwn(current, "_tag") &&
+      hasOwn(current, "_tag") &&
       current._tag === DI_TAG &&
-      Object.hasOwn(current, "key") &&
-      Object.hasOwn(current, DI_TOKEN)
+      hasOwn(current, "key") &&
+      hasOwn(current, DI_TOKEN)
     ) {
       return unsafeCoerce<AnyDependency>(current);
     }
@@ -289,5 +286,5 @@ export function provideOp<
     return result.value;
   });
 
-  return unsafeCoerce<Op<T, E, A, ProvidedMeta<M, Entries>>>(provided);
+  return unsafeCoerce(provided);
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -4,7 +4,6 @@
   "description": "Maintainer tooling for the prodkit monorepo",
   "type": "module",
   "scripts": {
-    "gate": "pnpm run typecheck && pnpm run lint && pnpm run fmt:check && pnpm run smoke",
     "examples:smoke:pack": "node ./run-examples-smoke.ts pack",
     "examples:smoke:github": "node ./run-examples-smoke.ts github",
     "examples:smoke:npm": "node ./run-examples-smoke.ts npm",

--- a/tools/run-runtime-smoke.ts
+++ b/tools/run-runtime-smoke.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
-import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -211,18 +211,16 @@ async function smokeDeno(workspaceDir: string) {
   );
 }
 
+function rewriteBetterResultImports(content: string): string {
+  return content.replaceAll(/(from\s*["'])better-result(["'])/g, "$1./better-result.mjs$2");
+}
+
 async function smokeEdge(workspaceDir: string) {
   const edgeDir = path.join(workspaceDir, "edge");
   mkdirSync(edgeDir);
 
-  const opEntryPath = path.join(
-    workspaceDir,
-    "node_modules",
-    "@prodkit",
-    "op",
-    "dist",
-    "index.mjs",
-  );
+  const opDistDir = path.join(workspaceDir, "node_modules", "@prodkit", "op", "dist");
+  const opEntryPath = path.join(opDistDir, "index.mjs");
   const resultEntryPath = path.join(
     workspaceDir,
     "node_modules",
@@ -234,16 +232,15 @@ async function smokeEdge(workspaceDir: string) {
   if (!existsSync(resultEntryPath))
     throw new Error(`Missing better-result entry: ${resultEntryPath}`);
 
-  const opEntry = await readFile(opEntryPath, "utf8");
-  await writeFile(
-    path.join(edgeDir, "prodkit-op.mjs"),
-    opEntry.replaceAll(/(from\s*["'])better-result(["'])/g, "$1./better-result.mjs$2"),
-    "utf8",
-  );
+  for (const file of await readdir(opDistDir)) {
+    if (!file.endsWith(".mjs") || file === "internal.mjs") continue;
+    const content = await readFile(path.join(opDistDir, file), "utf8");
+    await writeFile(path.join(edgeDir, file), rewriteBetterResultImports(content), "utf8");
+  }
   await cp(resultEntryPath, path.join(edgeDir, "better-result.mjs"));
   await writeFile(
     path.join(edgeDir, "worker.mjs"),
-    `${smokeSource("./prodkit-op.mjs", "./better-result.mjs")}
+    `${smokeSource("./index.mjs", "./better-result.mjs")}
 
 export default {
   async fetch() {

--- a/turbo.json
+++ b/turbo.json
@@ -31,10 +31,6 @@
     "fmt:check": {
       "inputs": ["src/**/*.ts", "**/*.ts"]
     },
-    "gate": {
-      "dependsOn": ["^gate"],
-      "cache": false
-    },
     "smoke": {
       "dependsOn": ["build", "^build"],
       "cache": false


### PR DESCRIPTION
## summary

`Op` gets a fourth metadata param so extensions can attach typed metadata without wrapping core ops. run gating is generic `Blocking<T>` metadata now (or `withBlocking(...)`), not a DI-specific latch. DI uses that: plain `Op(...)` with `yield* DI.inject(...)`, then `DI.provide(op, ...bindings)` before `.run()` is available

custom instructions are symbol-branded at runtime, resolve through `RunContext.extensions`, and metadata flows through inference/composition via `MergeMeta` so fluent combinators keep one merged metadata object

breaking DI cut: `DI.Op`, `DI.require`, and `.use(...)` are gone. shared type helpers live on `@prodkit/op/internal` with more type-level and runtime coverage. root `pnpm run gate` is two phases now (build/typecheck/test/lint/fmt:check, then `@prodkit/tools` pack smoke) so examples smoke doesn't race `dist/` rebuilds

## validation

- `pnpm run gate`

spot check with
- `pnpm --filter @prodkit/op test`
- `pnpm --filter @prodkit/std test`
- `pnpm --filter @prodkit/examples run smoke`

quick manual pass: small op with `yield* DI.inject(...)`, confirm `.run()` is blocked until `DI.provide(...)`, then run it