### PR TITLE
Fix deep fluent and policy stack safety

### DIFF
--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Deep fluent and policy chains now execute stack-safely instead of resolving to
+  `Err(UnhandledException)` or throwing from `.run()` when valid compositions get large.
 - Corrected bundle size figures in the published performance docs; the main entry is now measured
   as a bundled graph (`better-result` externalized), with a consumer subpath upper bound
   (`di`, `policy`, `hkt`).
@@ -432,5 +434,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paths, including generator finalization behavior.
 - Tightened combinator and policy behavior in edge cases (listener teardown,
   retry timing, and composed operation semantics).
-
 

--- a/packages/op/src/core/plan/base.ts
+++ b/packages/op/src/core/plan/base.ts
@@ -15,9 +15,22 @@ import type { Instruction } from "../instructions.js";
 import type { EmptyMeta } from "../meta.js";
 
 export const OP_PLAN_BIND: unique symbol = Symbol("prodkit.op.plan-bind");
+const PLAN_UNARY_REWRITE: unique symbol = Symbol("prodkit.op.plan-unary-rewrite");
 
 type PlanInstruction<_E, M> = Instruction<unknown, M>;
 type PlanIterator<T, E, M> = Generator<PlanInstruction<E, M>, T, unknown>;
+type ErasedPlan = Plan<unknown, unknown, unknown>;
+type UnaryPlanRewrite = {
+  readonly source: ErasedPlan;
+  readonly rebuild: (rewrittenSource: ErasedPlan) => ErasedPlan;
+};
+type PlanExecutionJob = {
+  readonly plan: ErasedPlan;
+  readonly context: RunContext<readonly unknown[]>;
+  readonly mode: PlanExecutionMode;
+  readonly resolve: (result: Result<unknown, unknown | UnhandledException>) => void;
+  readonly reject: (cause: unknown) => void;
+};
 
 export type { PlanExecutionMode };
 
@@ -26,6 +39,7 @@ export interface Plan<T, E, M = EmptyMeta> {
     context: RunContext<readonly unknown[]>,
     mode?: PlanExecutionMode,
   ) => Promise<Result<T, E | UnhandledException>>;
+  readonly [PLAN_UNARY_REWRITE]?: UnaryPlanRewrite;
   readonly iterate: () => PlanIterator<T, E, M>;
   readonly rewrite: <TNext, ENext, MNext>(rewriter: PlanRewriter) => Plan<TNext, ENext, MNext>;
 }
@@ -53,7 +67,12 @@ export function rewriteUnaryPlan<T, E, M>(
   source: Plan<T, E, M>,
   rebuild: (rewrittenSource: Plan<T, E, M>) => Plan<unknown, unknown, unknown>,
 ): Plan<unknown, unknown, unknown> {
-  return rebuild(source.rewrite(rewriter));
+  // SAFETY: rewrite metadata erases source generics; the caller-owned rebuild restores the wrapper-local source type.
+  const erasedSource: ErasedPlan = unsafeCoerce(source);
+  const rewritten = rewritePlanStackSafe(erasedSource, rewriter);
+  // SAFETY: rewritePlanStackSafe rewrites the same source slot captured by this unary wrapper.
+  const typedRewritten: Plan<T, E, M> = unsafeCoerce(rewritten);
+  return rebuild(typedRewritten);
 }
 
 interface PlanRewriteOverrides<T, E, M> {
@@ -79,17 +98,117 @@ export function createPlan<T, E, M>(
   return plan;
 }
 
+export function createUnaryPlan<T, E, M, TSource, ESource, MSource>(
+  iterate: () => PlanIterator<T, E, M>,
+  source: Plan<TSource, ESource, MSource>,
+  rebuild: (rewrittenSource: Plan<TSource, ESource, MSource>) => Plan<unknown, unknown, unknown>,
+): Plan<T, E, M> {
+  // SAFETY: unary rewrite metadata is intentionally erased so stack-safe rewrite can collect heterogenous frames.
+  const erasedSource: ErasedPlan = unsafeCoerce(source);
+  const erasedRebuild: UnaryPlanRewrite["rebuild"] = (rewrittenSource) => {
+    // SAFETY: rewrittenSource is produced by rewriting the same source slot captured above.
+    const typedSource: Plan<TSource, ESource, MSource> = unsafeCoerce(rewrittenSource);
+    return rebuild(typedSource);
+  };
+  const plan = createPlan(iterate, {
+    rewrite: (_self, rewriter) => rewriteUnaryPlan(rewriter, source, rebuild),
+  });
+  Object.defineProperty(plan, PLAN_UNARY_REWRITE, {
+    value: { source: erasedSource, rebuild: erasedRebuild } satisfies UnaryPlanRewrite,
+  });
+  return plan;
+}
+
+function rewritePlanStackSafe(source: ErasedPlan, rewriter: PlanRewriter): ErasedPlan {
+  const rebuilds: UnaryPlanRewrite["rebuild"][] = [];
+  let current = source;
+
+  while (true) {
+    const unary = current[PLAN_UNARY_REWRITE];
+    if (unary === undefined) break;
+    rebuilds.push(unary.rebuild);
+    current = unary.source;
+  }
+
+  let rewritten = current.rewrite(rewriter);
+  for (let index = rebuilds.length - 1; index >= 0; index -= 1) {
+    const rebuild = rebuilds[index];
+    if (rebuild !== undefined) rewritten = rebuild(rewritten);
+  }
+  return rewritten;
+}
+
 export function interruptOnAbortMode(context: RunContext<readonly unknown[]>): PlanExecutionMode {
   return CancelSettlement.interruptOnAbort(() => signalAbortReason(context.signal));
 }
+
+let activePlanExecutionCount = 0;
+const planExecutionQueue: PlanExecutionJob[] = [];
+let planExecutionPumpScheduled = false;
+const MAX_SYNC_PLAN_EXECUTION_DEPTH = 128;
 
 export function executePlan<T, E, M>(
   plan: Plan<T, E, M>,
   context: RunContext<readonly unknown[]>,
   mode: PlanExecutionMode = CancelSettlement.passThrough,
 ): Promise<Result<T, E | UnhandledException>> {
-  // SAFETY: driveIterator may return UnhandledException; executePlan widens E for settlement faults.
-  return unsafeCoerce(driveIterator(plan.iterate(), context, mode));
+  if (activePlanExecutionCount < MAX_SYNC_PLAN_EXECUTION_DEPTH) {
+    return executePlanDirect(plan, context, mode);
+  }
+
+  return enqueuePlanExecution(plan, context, mode);
+}
+
+async function executePlanDirect<T, E, M>(
+  plan: Plan<T, E, M>,
+  context: RunContext<readonly unknown[]>,
+  mode: PlanExecutionMode,
+): Promise<Result<T, E | UnhandledException>> {
+  activePlanExecutionCount += 1;
+  try {
+    // SAFETY: driveIterator may return UnhandledException; executePlan widens E for settlement faults.
+    return unsafeCoerce(await driveIterator(plan.iterate(), context, mode));
+  } finally {
+    activePlanExecutionCount -= 1;
+  }
+}
+
+function enqueuePlanExecution<T, E, M>(
+  plan: Plan<T, E, M>,
+  context: RunContext<readonly unknown[]>,
+  mode: PlanExecutionMode,
+): Promise<Result<T, E | UnhandledException>> {
+  return new Promise((resolve, reject) => {
+    // SAFETY: queued jobs erase plan generics and restore them through the typed promise returned by executePlan.
+    const erasedPlan: ErasedPlan = unsafeCoerce(plan);
+    // SAFETY: the queued result is the same Result shape, with generics erased at the queue boundary only.
+    const erasedResolve: PlanExecutionJob["resolve"] = unsafeCoerce(resolve);
+    planExecutionQueue.push({
+      plan: erasedPlan,
+      context,
+      mode,
+      resolve: erasedResolve,
+      reject,
+    });
+    schedulePlanExecutionPump();
+  });
+}
+
+function schedulePlanExecutionPump() {
+  if (planExecutionPumpScheduled) return;
+  planExecutionPumpScheduled = true;
+  queueMicrotask(pumpPlanExecutionQueue);
+}
+
+function pumpPlanExecutionQueue() {
+  planExecutionPumpScheduled = false;
+
+  while (true) {
+    const job = planExecutionQueue.shift();
+    if (job === undefined) return;
+
+    void executePlanDirect(job.plan, job.context, job.mode).then(job.resolve, job.reject);
+  }
 }
 
 export function genPlan<T, E, M>(

--- a/packages/op/src/core/plan/lifecycle.ts
+++ b/packages/op/src/core/plan/lifecycle.ts
@@ -8,13 +8,13 @@ import {
 } from "../instructions.js";
 import type { EnterContext, EnterFn, ExitFn } from "./context.js";
 import type { ExitContext } from "../runtime.js";
-import { createPlan, rewriteUnaryPlan, type Plan } from "./base.js";
+import { createUnaryPlan, type Plan } from "./base.js";
 
 export function onEnterPlan<T, E, A, M>(
   source: Plan<T, E, M>,
   initialize: EnterFn<A>,
 ): Plan<T, E, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       yield new SuspendInstruction(async (context) => {
         const enterCtx: EnterContext<A> = {
@@ -33,10 +33,8 @@ export function onEnterPlan<T, E, A, M>(
       if (result.isErr()) return yield* result;
       return result.value;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => onEnterPlan(inner, initialize)),
-    },
+    source,
+    (inner) => onEnterPlan(inner, initialize),
   );
 }
 
@@ -44,7 +42,7 @@ export function onExitPlan<T, E, A, M>(
   source: Plan<T, E, M>,
   finalize: ExitFn<T, E, A>,
 ): Plan<T, E, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       yield new RegisterExitFinalizerInstruction(async (ctx) => {
         const exitCtx: ExitContext<T, E, A> = {
@@ -65,9 +63,7 @@ export function onExitPlan<T, E, A, M>(
       if (result.isErr()) return yield* result;
       return result.value;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => onExitPlan(inner, finalize)),
-    },
+    source,
+    (inner) => onExitPlan(inner, finalize),
   );
 }

--- a/packages/op/src/core/plan/shell.ts
+++ b/packages/op/src/core/plan/shell.ts
@@ -32,10 +32,24 @@ import {
 
 type PlanShellContext<T, E, A, M> = {
   bindArgs: PlanBinder<T, E, A, M>;
-  withPolicyIterable: <TNext, ENext, MNext>(
-    transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
-  ) => (() => Plan<TNext, ENext, MNext>) | undefined;
+  makeIterable: (() => Plan<T, E, M>) | undefined;
   bound: boolean;
+};
+
+type ErasedPlan = Plan<unknown, unknown, unknown>;
+type ErasedPlanFactory = (...args: readonly unknown[]) => ErasedPlan;
+type ErasedPlanTransform = (plan: ErasedPlan) => ErasedPlan;
+const PLAN_FACTORY_CHAIN: unique symbol = Symbol("prodkit.op.plan-factory-chain");
+type PlanTransformNode = {
+  readonly previous: PlanTransformNode | undefined;
+  readonly transform: ErasedPlanTransform;
+};
+type PlanFactoryChain = {
+  readonly base: ErasedPlanFactory;
+  readonly tail: PlanTransformNode | undefined;
+};
+type ChainablePlanFactory = ErasedPlanFactory & {
+  readonly [PLAN_FACTORY_CHAIN]?: PlanFactoryChain;
 };
 
 type PolicyWrapFn = <TNext, ENext, MNext>(
@@ -97,11 +111,69 @@ function wrapPlanTransform<T, E, A, M, Yieldable extends boolean, TNext, ENext, 
   ctx: PlanShellContext<T, E, A, M>,
   transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
 ): OpInterface<TNext, ENext, A, MNext, Yieldable> {
-  return makePlanOp<TNext, ENext, A, MNext, Yieldable>(
-    (...args) => transform(ctx.bindArgs(...args)),
-    ctx.withPolicyIterable(transform),
-    ctx.bound,
-  );
+  const bindArgs = appendPlanBinder(ctx.bindArgs, transform);
+  const makeIterable =
+    ctx.makeIterable === undefined ? undefined : appendPlanProvider(ctx.makeIterable, transform);
+
+  return makePlanOp<TNext, ENext, A, MNext, Yieldable>(bindArgs, makeIterable, ctx.bound);
+}
+
+function appendPlanBinder<T, E, A, M, TNext, ENext, MNext>(
+  bindArgs: PlanBinder<T, E, A, M>,
+  transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
+): PlanBinder<TNext, ENext, A, MNext> {
+  // SAFETY: transform chains erase plan generics until bind time, then restore the typed binder surface.
+  const erasedBindArgs: ErasedPlanFactory = unsafeCoerce(bindArgs);
+  // SAFETY: transform closes over the source plan generics; the erased chain preserves transform order only.
+  const erasedTransform: ErasedPlanTransform = unsafeCoerce(transform);
+  const appended = appendPlanTransform(erasedBindArgs, erasedTransform);
+  // SAFETY: appended binder keeps the original args tuple and returns the transform's next plan type.
+  return unsafeCoerce(appended);
+}
+
+function appendPlanProvider<T, E, M, TNext, ENext, MNext>(
+  provider: () => Plan<T, E, M>,
+  transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
+): () => Plan<TNext, ENext, MNext> {
+  // SAFETY: iterable providers are nullary plan factories; only plan generics are erased in the chain.
+  const erasedProvider: ErasedPlanFactory = unsafeCoerce(provider);
+  // SAFETY: transform closes over the source plan generics; the erased chain preserves transform order only.
+  const erasedTransform: ErasedPlanTransform = unsafeCoerce(transform);
+  const appended = appendPlanTransform(erasedProvider, erasedTransform);
+  // SAFETY: appended provider returns the transform's next plan type.
+  return unsafeCoerce(appended);
+}
+
+function appendPlanTransform(
+  factory: ErasedPlanFactory,
+  transform: ErasedPlanTransform,
+): ErasedPlanFactory {
+  const chain = getPlanFactoryChain(factory);
+  const tail: PlanTransformNode = { previous: chain.tail, transform };
+  const next: ErasedPlanFactory = (...args) => applyPlanTransforms(chain.base(...args), tail);
+  Object.defineProperty(next, PLAN_FACTORY_CHAIN, {
+    value: { base: chain.base, tail } satisfies PlanFactoryChain,
+  });
+  return next;
+}
+
+function getPlanFactoryChain(factory: ErasedPlanFactory): PlanFactoryChain {
+  const chainable: ChainablePlanFactory = factory;
+  return chainable[PLAN_FACTORY_CHAIN] ?? { base: factory, tail: undefined };
+}
+
+function applyPlanTransforms(source: ErasedPlan, tail: PlanTransformNode): ErasedPlan {
+  const transforms: ErasedPlanTransform[] = [];
+  for (let node: PlanTransformNode | undefined = tail; node !== undefined; node = node.previous) {
+    transforms.push(node.transform);
+  }
+
+  let plan = source;
+  for (let index = transforms.length - 1; index >= 0; index -= 1) {
+    const transform = transforms[index];
+    if (transform !== undefined) plan = transform(plan);
+  }
+  return plan;
 }
 
 function fluentMethodsForContext<T, E, A, M, Yieldable extends boolean>(
@@ -151,7 +223,7 @@ function syncValueShellContext<T>(
 ): PlanShellContext<T, never, [], EmptyMeta> {
   return {
     bindArgs: () => self[OP_PLAN_BIND](),
-    withPolicyIterable: (transform) => () => transform(self[OP_PLAN_BIND]()),
+    makeIterable: () => self[OP_PLAN_BIND](),
     bound: true,
   };
 }
@@ -218,13 +290,9 @@ export function makePlanOp<
           )
       : undefined);
 
-  const withPolicyIterable = <TNext, ENext, MNext>(
-    transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
-  ) => (iterable === undefined ? undefined : () => transform(iterable()));
-
   const shellContext: PlanShellContext<T, E, A, M> = {
     bindArgs,
-    withPolicyIterable,
+    makeIterable: iterable,
     bound,
   };
 

--- a/packages/op/src/core/plan/transforms.ts
+++ b/packages/op/src/core/plan/transforms.ts
@@ -12,7 +12,7 @@ import type {
   TrackedErr,
 } from "./surface.js";
 import type { MergeMeta } from "../meta.js";
-import { createPlan, getPlan, rewriteUnaryPlan, type Plan } from "./base.js";
+import { createPlan, createUnaryPlan, getPlan, type Plan } from "./base.js";
 
 function isRuntimeBypass(error: unknown): error is UnhandledException | TimeoutError {
   return UnhandledException.is(error) || TimeoutError.is(error);
@@ -22,7 +22,7 @@ export function mapPlan<T, E, U, M>(
   source: Plan<T, E, M>,
   transform: (value: T) => U,
 ): Plan<Awaited<U>, E, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context) => source.execute(context),
@@ -38,10 +38,8 @@ export function mapPlan<T, E, U, M>(
 
       return mapped;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => mapPlan(inner, transform)),
-    },
+    source,
+    (inner) => mapPlan(inner, transform),
   );
 }
 
@@ -78,7 +76,7 @@ export function tapPlan<T, E, R, M>(
   source: Plan<T, E, M>,
   observe: (value: T) => R,
 ): Plan<T, E, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const sourceResult: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context) => source.execute(context),
@@ -93,10 +91,8 @@ export function tapPlan<T, E, R, M>(
       );
       return sourceResult.value;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => tapPlan(inner, observe)),
-    },
+    source,
+    (inner) => tapPlan(inner, observe),
   );
 }
 
@@ -104,7 +100,7 @@ export function mapErrPlan<T, E, E2, M>(
   source: Plan<T, E, M>,
   transform: (error: TrackedErr<E>) => E2,
 ): Plan<T, E2 | BypassedErr<E>, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context) => source.execute(context),
@@ -126,10 +122,8 @@ export function mapErrPlan<T, E, E2, M>(
 
       return yield* Result.err(mapped);
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => mapErrPlan(inner, transform)),
-    },
+    source,
+    (inner) => mapErrPlan(inner, transform),
   );
 }
 
@@ -137,7 +131,7 @@ export function tapErrPlan<T, E, R, M>(
   source: Plan<T, E, M>,
   observe: (error: TrackedErr<E>) => R,
 ): Plan<T, TrackedErr<E> | BypassedErr<E>, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const sourceResult: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context) => source.execute(context),
@@ -158,10 +152,8 @@ export function tapErrPlan<T, E, R, M>(
       );
       return yield* sourceResult;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => tapErrPlan(inner, observe)),
-    },
+    source,
+    (inner) => tapErrPlan(inner, observe),
   );
 }
 
@@ -170,7 +162,7 @@ export function recoverPlan<T, E, ECaught extends TrackedErr<E>, R, M>(
   predicate: (error: TrackedErr<E>) => error is ECaught,
   handler: (error: ECaught) => R,
 ): Plan<T | Awaited<R>, TrackedErr<E, ECaught> | BypassedErr<E>, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context) => source.execute(context),
@@ -193,9 +185,7 @@ export function recoverPlan<T, E, ECaught extends TrackedErr<E>, R, M>(
 
       return recovered;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => recoverPlan(inner, predicate, handler)),
-    },
+    source,
+    (inner) => recoverPlan(inner, predicate, handler),
   );
 }

--- a/packages/op/src/di/internal.ts
+++ b/packages/op/src/di/internal.ts
@@ -1,6 +1,6 @@
 import {
   getPlan,
-  createPlan,
+  createUnaryPlan,
   executePlan,
   interruptOnAbortMode,
   type Plan,
@@ -274,7 +274,7 @@ export function providePlan<T, E, M>(
 ): Plan<T, E, M> {
   const snapshot = bindings.slice();
 
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context: RunContext<readonly unknown[]>) =>
@@ -289,9 +289,8 @@ export function providePlan<T, E, M>(
       if (result.isErr()) return yield* result;
       return result.value;
     },
-    {
-      rewrite: (_self, rewriter) => providePlan(source.rewrite(rewriter), snapshot),
-    },
+    source,
+    (inner) => providePlan(inner, snapshot),
   );
 }
 

--- a/packages/op/src/policy/plan.ts
+++ b/packages/op/src/policy/plan.ts
@@ -14,9 +14,9 @@ import type { ReleaseFn } from "../core/plan/context.js";
 import type { RunContext } from "../core/runtime.js";
 import {
   createPlan,
+  createUnaryPlan,
   executePlan,
   interruptOnAbortMode,
-  rewriteUnaryPlan,
   type Plan,
   type PlanRewriter,
 } from "../core/plan/base.js";
@@ -26,7 +26,7 @@ function policyRewriter(apply: PlanRewriter["apply"]): PlanRewriter {
 }
 
 export function releasePlan<T, E, M>(source: Plan<T, E, M>, release: ReleaseFn<T>): Plan<T, E, M> {
-  return createPlan(
+  return createUnaryPlan(
     function* () {
       const result: Result<T, E | UnhandledException> = yield* new SuspendInstruction(
         (context) => source.execute(context),
@@ -41,10 +41,8 @@ export function releasePlan<T, E, M>(source: Plan<T, E, M>, release: ReleaseFn<T
 
       return result.value;
     },
-    {
-      rewrite: (_self, rewriter) =>
-        rewriteUnaryPlan(rewriter, source, (inner) => releasePlan(inner, release)),
-    },
+    source,
+    (inner) => releasePlan(inner, release),
   );
 }
 

--- a/packages/op/tests/unit/stack-safety.test.ts
+++ b/packages/op/tests/unit/stack-safety.test.ts
@@ -1,0 +1,74 @@
+import { assert, describe, expect, test } from "vitest";
+import { Op } from "../../src/index.js";
+import { UnhandledException } from "../../src/errors.js";
+
+/**
+ * Deep-composition stack safety.
+ *
+ * The generator path trampolines through the async driver and is stack-safe.
+ * The fluent / plan-wrapping path (`map`, `flatMap`, `tap`, `mapErr`, `recover`,
+ * `on`, and `with(Policy.*)`) descends synchronously through one plan layer per
+ * combinator before the first suspend, so a chain a few thousand deep exhausts
+ * the call stack.
+ *
+ * Two failure bands, both observed on Node 22/24:
+ *   - ~2_000 .. ~8_400 links: `.run()` resolves to Err(UnhandledException) whose
+ *     cause is a RangeError. The result is silently wrong (an error, not the value).
+ *   - above ~8_400 links: `.run()` throws the RangeError synchronously, violating
+ *     the contract (ADR-0005 / DESIGN.md) that `.run()` always resolves to a Result.
+ */
+describe("deep composition stack safety", () => {
+  // Control: passes today. Idiomatic generator composition is stack-safe.
+  test("generator yield* loop returns the correct value at depth 50_000", async () => {
+    const depth = 50_000;
+    const op = Op(function* () {
+      let acc = 0;
+      for (let i = 0; i < depth; i += 1) acc += yield* Op.of(1);
+      return acc;
+    });
+
+    const result = await op.run();
+    assert(result.isOk(), "generator loop should succeed");
+    expect(result.value).toBe(depth);
+  });
+
+  // BUG (silent-error band): currently resolves to Err(UnhandledException).
+  test("flatMap chain returns the correct value at depth 3_000", async () => {
+    const depth = 3_000;
+    let op = Op.of(0);
+    for (let i = 0; i < depth; i += 1) op = op.flatMap((x) => Op.of(x + 1));
+
+    const result = await op.run();
+    assert(
+      result.isOk(),
+      "deep flatMap chain should succeed, not fail with a stack-overflow UnhandledException",
+    );
+    expect(result.value).toBe(depth);
+  });
+
+  // BUG (silent-error band): map has the same shape, with a slightly higher onset.
+  test("map chain returns the correct value at depth 3_000", async () => {
+    const depth = 3_000;
+    let op = Op.of(0);
+    for (let i = 0; i < depth; i += 1) op = op.map((x) => x + 1);
+
+    const result = await op.run();
+    assert(result.isOk(), "deep map chain should succeed");
+    expect(result.value).toBe(depth);
+  });
+
+  // BUG (throw band): `.run()` must resolve to a Result, never throw.
+  test("run() resolves to a Result for a very deep chain instead of throwing", async () => {
+    const depth = 20_000;
+    let op = Op.of(0);
+    for (let i = 0; i < depth; i += 1) op = op.flatMap((x) => Op.of(x + 1));
+
+    // The contract is that runtime faults settle on the UnhandledException
+    // channel. Awaiting must not throw.
+    const result = await op.run();
+    assert(
+      result.isOk() || (result.isErr() && UnhandledException.is(result.error)),
+      "run() should resolve to a Result",
+    );
+  });
+});

--- a/packages/op/tests/unit/stack-safety.test.ts
+++ b/packages/op/tests/unit/stack-safety.test.ts
@@ -1,24 +1,16 @@
 import { assert, describe, expect, test } from "vitest";
 import { Op } from "../../src/index.js";
 import { UnhandledException } from "../../src/errors.js";
+import { Policy } from "../../src/policy/index.js";
 
 /**
- * Deep-composition stack safety.
+ * Regression coverage for deep-composition stack safety.
  *
  * The generator path trampolines through the async driver and is stack-safe.
- * The fluent / plan-wrapping path (`map`, `flatMap`, `tap`, `mapErr`, `recover`,
- * `on`, and `with(Policy.*)`) descends synchronously through one plan layer per
- * combinator before the first suspend, so a chain a few thousand deep exhausts
- * the call stack.
- *
- * Two failure bands, both observed on Node 22/24:
- *   - ~2_000 .. ~8_400 links: `.run()` resolves to Err(UnhandledException) whose
- *     cause is a RangeError. The result is silently wrong (an error, not the value).
- *   - above ~8_400 links: `.run()` throws the RangeError synchronously, violating
- *     the contract (ADR-0005 / DESIGN.md) that `.run()` always resolves to a Result.
+ * The fluent / plan-wrapping path should also bind and execute deep valid
+ * compositions without treating stack depth as a runtime fault.
  */
 describe("deep composition stack safety", () => {
-  // Control: passes today. Idiomatic generator composition is stack-safe.
   test("generator yield* loop returns the correct value at depth 50_000", async () => {
     const depth = 50_000;
     const op = Op(function* () {
@@ -32,7 +24,6 @@ describe("deep composition stack safety", () => {
     expect(result.value).toBe(depth);
   });
 
-  // BUG (silent-error band): currently resolves to Err(UnhandledException).
   test("flatMap chain returns the correct value at depth 3_000", async () => {
     const depth = 3_000;
     let op = Op.of(0);
@@ -46,7 +37,6 @@ describe("deep composition stack safety", () => {
     expect(result.value).toBe(depth);
   });
 
-  // BUG (silent-error band): map has the same shape, with a slightly higher onset.
   test("map chain returns the correct value at depth 3_000", async () => {
     const depth = 3_000;
     let op = Op.of(0);
@@ -57,7 +47,18 @@ describe("deep composition stack safety", () => {
     expect(result.value).toBe(depth);
   });
 
-  // BUG (throw band): `.run()` must resolve to a Result, never throw.
+  test("mixed policy and fluent wrapper chain returns the correct value at depth 3_000", async () => {
+    const depth = 3_000;
+    let op = Op.of(0);
+    for (let i = 0; i < depth; i += 1) {
+      op = op.with(Policy.retry({ retries: 0 })).map((x) => x + 1);
+    }
+
+    const result = await op.run();
+    assert(result.isOk(), "deep policy/fluent chain should succeed");
+    expect(result.value).toBe(depth);
+  });
+
   test("run() resolves to a Result for a very deep chain instead of throwing", async () => {
     const depth = 20_000;
     let op = Op.of(0);


### PR DESCRIPTION
## Summary

Deep fluent and policy compositions now bind and execute stack-safely instead of overflowing before the first async boundary. Valid folded pipelines return the expected Ok value at the regression depths, and very deep `.run()` paths keep resolving to `Result`.

The plan runtime now flattens unary rewrite chains, applies fluent wrappers through an iterative transform chain, and uses a bounded execution trampoline so shallow concurrency and cancellation timing stays unchanged.

Before the fix, repeated `Op.of(0).flatMap(...)` or `.map(...)` chains at a few thousand links resolved to `Err(UnhandledException)` with a stack overflow cause, and a very deep chain could throw `RangeError` out of `.run()`.

## Validation Steps

- `pnpm --filter @prodkit/op run typecheck`
- `pnpm --filter @prodkit/op run lint`
- `pnpm --filter @prodkit/op run fmt:check`
- `pnpm --filter @prodkit/op run test`
- `pnpm run gate`