### PR TITLE
bind interleaved policy and fluent chains in linear time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -41,7 +42,7 @@ jobs:
 
       - name: Run project quality gate
         env:
-          CHANGELOG_API_BASE_REF: ${{ github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000' && github.event.before || '' }}
+          CHANGELOG_API_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000' && github.event.before) || '' }}
         run: pnpm run gate
 
       - name: Publish op coverage report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,9 @@ file paths that no longer exist in the repo.
 A `changelog:api:check` gate step fails when `packages/op/src/index.ts`,
 `packages/op/src/di/index.ts`, `packages/op/src/policy/index.ts`, or `packages/op/src/hkt.ts`
 public export names change without an update to that package's `CHANGELOG.md` under
-`## [Unreleased]`. The check compares against an explicit base ref (`GITHUB_BASE_SHA` on pull
-requests, the pre-push commit on pushes to `main`, or `CHANGELOG_API_BASE_REF` locally) and fails
+`## [Unreleased]`. The check compares against an explicit base ref (`pull_request.base.sha` on pull
+requests via `CHANGELOG_API_BASE_REF`, the pre-push commit on pushes to `main`, or
+`CHANGELOG_API_BASE_REF` locally) and fails
 closed when no base ref can be resolved. Internal re-export paths do not count as API changes.
 A `bundle-size` job compares `@prodkit/op` lower and upper bundled size bounds (minified + gzip)
 on pull requests via `compressed-size-action`; runtime regressions are tracked separately by CodSpeed

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deep fluent and policy chains now execute stack-safely instead of resolving to
   `Err(UnhandledException)` or throwing from `.run()` when valid compositions get large.
+- Interleaved fluent transforms and push-through policies (for example
+  `.with(Policy.retry(...)).map(...)`) now bind in linear time instead of quadratic time at
+  `.run()` / `yield*`, with unchanged push-through semantics.
 - Corrected bundle size figures in the published performance docs; the main entry is now measured
   as a bundled graph (`better-result` externalized), with a consumer subpath upper bound
   (`di`, `policy`, `hkt`).

--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interleaved fluent transforms and push-through policies (for example
   `.with(Policy.retry(...)).map(...)`) now bind in linear time instead of quadratic time at
   `.run()` / `yield*`, with unchanged push-through semantics.
+- Stacking push-through policies on an op whose bound plan is already a deep unary chain (for
+  example after invoking a parameterized op built with many `.map(...)` layers) no longer re-walks
+  that entry depth once per policy at bind time.
 - Corrected bundle size figures in the published performance docs; the main entry is now measured
   as a bundled graph (`better-result` externalized), with a consumer subpath upper bound
   (`di`, `policy`, `hkt`).

--- a/packages/op/src/core/plan/base.ts
+++ b/packages/op/src/core/plan/base.ts
@@ -119,6 +119,30 @@ export function createUnaryPlan<T, E, M, TSource, ESource, MSource>(
   return plan;
 }
 
+/**
+ * Splits a plan's leading run of unary wrappers from its nearest non-unary node.
+ *
+ * Returned `wraps` are innermost-first, matching left-to-right application order:
+ * `wraps.reduce((plan, wrap) => wrap(plan), base)` reconstructs the input plan.
+ */
+export function splitLeadingUnaryWraps(plan: ErasedPlan): {
+  readonly base: ErasedPlan;
+  readonly wraps: ReadonlyArray<UnaryPlanRewrite["rebuild"]>;
+} {
+  const wraps: UnaryPlanRewrite["rebuild"][] = [];
+  let current = plan;
+
+  while (true) {
+    const unary = current[PLAN_UNARY_REWRITE];
+    if (unary === undefined) break;
+    wraps.push(unary.rebuild);
+    current = unary.source;
+  }
+
+  wraps.reverse();
+  return { base: current, wraps };
+}
+
 function rewritePlanStackSafe(source: ErasedPlan, rewriter: PlanRewriter): ErasedPlan {
   const rebuilds: UnaryPlanRewrite["rebuild"][] = [];
   let current = source;

--- a/packages/op/src/core/plan/shell.ts
+++ b/packages/op/src/core/plan/shell.ts
@@ -40,9 +40,11 @@ type ErasedPlan = Plan<unknown, unknown, unknown>;
 type ErasedPlanFactory = (...args: readonly unknown[]) => ErasedPlan;
 type ErasedPlanTransform = (plan: ErasedPlan) => ErasedPlan;
 const PLAN_FACTORY_CHAIN: unique symbol = Symbol("prodkit.op.plan-factory-chain");
+type TransformKind = "unaryWrap" | "pushPolicy" | "boundary";
 type PlanTransformNode = {
   readonly previous: PlanTransformNode | undefined;
   readonly transform: ErasedPlanTransform;
+  readonly kind: TransformKind;
 };
 type PlanFactoryChain = {
   readonly base: ErasedPlanFactory;
@@ -54,6 +56,7 @@ type ChainablePlanFactory = ErasedPlanFactory & {
 
 type PolicyWrapFn = <TNext, ENext, MNext>(
   transform: (plan: Plan<unknown, unknown, unknown>) => Plan<TNext, ENext, MNext>,
+  kind: TransformKind,
 ) => unknown;
 
 class PolicySourceImpl {
@@ -71,6 +74,7 @@ class PolicySourceImpl {
       this.wrapPlan(
         // SAFETY: PolicyWrapFn erases plan generics; transform closes over the source plan's T, E, M.
         unsafeCoerce(transform),
+        "boundary",
       ),
     );
   }
@@ -78,7 +82,7 @@ class PolicySourceImpl {
   rewrite<A, TNext, ENext, MNext>(rewriter: PlanRewriter): Op<TNext, ENext, AsArgs<A>, MNext> {
     // SAFETY: PolicyWrapFn returns unknown; rewrite already targeted TNext, ENext, MNext on the inner plan.
     return unsafeCoerce<Op<TNext, ENext, AsArgs<A>, MNext>>(
-      this.wrapPlan((plan) => plan.rewrite<TNext, ENext, MNext>(rewriter)),
+      this.wrapPlan((plan) => plan.rewrite<TNext, ENext, MNext>(rewriter), "pushPolicy"),
     );
   }
 
@@ -102,7 +106,7 @@ class PolicySourceImpl {
           if (result.isErr()) return yield* result;
           return result.value;
         });
-      }),
+      }, "boundary"),
     );
   }
 }
@@ -110,10 +114,13 @@ class PolicySourceImpl {
 function wrapPlanTransform<T, E, A, M, Yieldable extends boolean, TNext, ENext, MNext>(
   ctx: PlanShellContext<T, E, A, M>,
   transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
+  kind: TransformKind,
 ): OpInterface<TNext, ENext, A, MNext, Yieldable> {
-  const bindArgs = appendPlanBinder(ctx.bindArgs, transform);
+  const bindArgs = appendPlanBinder(ctx.bindArgs, transform, kind);
   const makeIterable =
-    ctx.makeIterable === undefined ? undefined : appendPlanProvider(ctx.makeIterable, transform);
+    ctx.makeIterable === undefined
+      ? undefined
+      : appendPlanProvider(ctx.makeIterable, transform, kind);
 
   return makePlanOp<TNext, ENext, A, MNext, Yieldable>(bindArgs, makeIterable, ctx.bound);
 }
@@ -121,12 +128,13 @@ function wrapPlanTransform<T, E, A, M, Yieldable extends boolean, TNext, ENext, 
 function appendPlanBinder<T, E, A, M, TNext, ENext, MNext>(
   bindArgs: PlanBinder<T, E, A, M>,
   transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
+  kind: TransformKind,
 ): PlanBinder<TNext, ENext, A, MNext> {
   // SAFETY: transform chains erase plan generics until bind time, then restore the typed binder surface.
   const erasedBindArgs: ErasedPlanFactory = unsafeCoerce(bindArgs);
   // SAFETY: transform closes over the source plan generics; the erased chain preserves transform order only.
   const erasedTransform: ErasedPlanTransform = unsafeCoerce(transform);
-  const appended = appendPlanTransform(erasedBindArgs, erasedTransform);
+  const appended = appendPlanTransform(erasedBindArgs, erasedTransform, kind);
   // SAFETY: appended binder keeps the original args tuple and returns the transform's next plan type.
   return unsafeCoerce(appended);
 }
@@ -134,12 +142,13 @@ function appendPlanBinder<T, E, A, M, TNext, ENext, MNext>(
 function appendPlanProvider<T, E, M, TNext, ENext, MNext>(
   provider: () => Plan<T, E, M>,
   transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
+  kind: TransformKind,
 ): () => Plan<TNext, ENext, MNext> {
   // SAFETY: iterable providers are nullary plan factories; only plan generics are erased in the chain.
   const erasedProvider: ErasedPlanFactory = unsafeCoerce(provider);
   // SAFETY: transform closes over the source plan generics; the erased chain preserves transform order only.
   const erasedTransform: ErasedPlanTransform = unsafeCoerce(transform);
-  const appended = appendPlanTransform(erasedProvider, erasedTransform);
+  const appended = appendPlanTransform(erasedProvider, erasedTransform, kind);
   // SAFETY: appended provider returns the transform's next plan type.
   return unsafeCoerce(appended);
 }
@@ -147,9 +156,10 @@ function appendPlanProvider<T, E, M, TNext, ENext, MNext>(
 function appendPlanTransform(
   factory: ErasedPlanFactory,
   transform: ErasedPlanTransform,
+  kind: TransformKind,
 ): ErasedPlanFactory {
   const chain = getPlanFactoryChain(factory);
-  const tail: PlanTransformNode = { previous: chain.tail, transform };
+  const tail: PlanTransformNode = { previous: chain.tail, transform, kind };
   const next: ErasedPlanFactory = (...args) => applyPlanTransforms(chain.base(...args), tail);
   Object.defineProperty(next, PLAN_FACTORY_CHAIN, {
     value: { base: chain.base, tail } satisfies PlanFactoryChain,
@@ -163,17 +173,46 @@ function getPlanFactoryChain(factory: ErasedPlanFactory): PlanFactoryChain {
 }
 
 function applyPlanTransforms(source: ErasedPlan, tail: PlanTransformNode): ErasedPlan {
-  const transforms: ErasedPlanTransform[] = [];
+  const nodes: PlanTransformNode[] = [];
   for (let node: PlanTransformNode | undefined = tail; node !== undefined; node = node.previous) {
-    transforms.push(node.transform);
+    nodes.push(node);
   }
 
-  let plan = source;
-  for (let index = transforms.length - 1; index >= 0; index -= 1) {
-    const transform = transforms[index];
-    if (transform !== undefined) plan = transform(plan);
+  let base = source;
+  const pendingUnaryWraps: ErasedPlanTransform[] = [];
+
+  const materialize = () => {
+    for (let index = 0; index < pendingUnaryWraps.length; index += 1) {
+      const wrap = pendingUnaryWraps[index];
+      if (wrap !== undefined) base = wrap(base);
+    }
+    pendingUnaryWraps.length = 0;
+  };
+
+  // nodes is tail..head; iterate head..tail to apply transforms in fluent-call order.
+  for (let index = nodes.length - 1; index >= 0; index -= 1) {
+    const node = nodes[index];
+    if (node === undefined) continue;
+
+    if (node.kind === "unaryWrap") {
+      pendingUnaryWraps.push(node.transform);
+      continue;
+    }
+
+    if (node.kind === "pushPolicy") {
+      // transform(base) is base.rewrite(rewriter); with deferred wraps, base is the nearest
+      // non-unary node, which is exactly the push-through target.
+      base = node.transform(base);
+      continue;
+    }
+
+    // boundary
+    materialize();
+    base = node.transform(base);
   }
-  return plan;
+
+  materialize();
+  return base;
 }
 
 function fluentMethodsForContext<T, E, A, M, Yieldable extends boolean>(
@@ -181,7 +220,8 @@ function fluentMethodsForContext<T, E, A, M, Yieldable extends boolean>(
 ) {
   const wrap = <TNext, ENext, MNext>(
     transform: (plan: Plan<T, E, M>) => Plan<TNext, ENext, MNext>,
-  ) => wrapPlanTransform<T, E, A, M, Yieldable, TNext, ENext, MNext>(ctx, transform);
+    kind: TransformKind = "unaryWrap",
+  ) => wrapPlanTransform<T, E, A, M, Yieldable, TNext, ENext, MNext>(ctx, transform, kind);
 
   // SAFETY: PolicySourceImpl is structural but unbranded; methods delegate through wrap with the same generics.
   const policySource: OpPolicySource<T, E, AsArgs<A>, M> = unsafeCoerce(new PolicySourceImpl(wrap));
@@ -208,7 +248,7 @@ function fluentMethodsForContext<T, E, A, M, Yieldable extends boolean>(
     mapErr: <E2>(transform: (error: TrackedErr<E>) => E2) =>
       wrap((plan) => mapErrPlan(plan, transform)),
     flatMap: <R extends AnyNullaryOp>(bind: (value: T) => R) =>
-      wrap((plan) => flatMapPlan(plan, bind)),
+      wrap((plan) => flatMapPlan(plan, bind), "boundary"),
     tap: <R>(observe: (value: T) => R) => wrap((plan) => tapPlan(plan, observe)),
     tapErr: <R>(observe: (error: TrackedErr<E>) => R) => wrap((plan) => tapErrPlan(plan, observe)),
     recover: <ECaught extends TrackedErr<E>, R>(

--- a/packages/op/src/core/plan/shell.ts
+++ b/packages/op/src/core/plan/shell.ts
@@ -15,6 +15,7 @@ import {
   OP_PLAN_BIND,
   createPlan,
   genPlan,
+  splitLeadingUnaryWraps,
   type Plan,
   type PlanBackedOp,
   type PlanBinder,
@@ -174,12 +175,25 @@ function getPlanFactoryChain(factory: ErasedPlanFactory): PlanFactoryChain {
 
 function applyPlanTransforms(source: ErasedPlan, tail: PlanTransformNode): ErasedPlan {
   const nodes: PlanTransformNode[] = [];
+  let hasPushPolicy = false;
   for (let node: PlanTransformNode | undefined = tail; node !== undefined; node = node.previous) {
     nodes.push(node);
+    if (node.kind === "pushPolicy") hasPushPolicy = true;
   }
 
   let base = source;
   const pendingUnaryWraps: ErasedPlanTransform[] = [];
+
+  // When a push-through policy is present and the entry plan is itself a deep unary chain (for
+  // example an already-folded op reached through `getPlan`/`invoke`), split the entry plan's leading
+  // unary wrappers up front. That keeps `base` shallow so each `pushPolicy` rewrites it in O(1)
+  // instead of re-walking and rebuilding the entry chain per policy. A shallow (non-unary) entry
+  // short-circuits the split in O(1), so the common case is unaffected.
+  if (hasPushPolicy) {
+    const split = splitLeadingUnaryWraps(source);
+    base = split.base;
+    for (const wrap of split.wraps) pendingUnaryWraps.push(wrap);
+  }
 
   const materialize = () => {
     for (let index = 0; index < pendingUnaryWraps.length; index += 1) {

--- a/packages/op/tests/unit/stack-safety.test.ts
+++ b/packages/op/tests/unit/stack-safety.test.ts
@@ -47,6 +47,25 @@ describe("deep composition stack safety", () => {
     expect(result.value).toBe(depth);
   });
 
+  test("stacked policies on invoked deep unary op return the correct value", async () => {
+    const unaryDepth = 800;
+    const policyCount = 128;
+
+    let op = Op(function* (x: number) {
+      return x;
+    });
+    for (let i = 0; i < unaryDepth; i += 1) op = op.map((x) => x + 1);
+
+    let bound = op(unaryDepth);
+    for (let i = 0; i < policyCount; i += 1) {
+      bound = bound.with(Policy.retry({ retries: 0 }));
+    }
+
+    const result = await bound.run();
+    assert(result.isOk(), "stacked policies on invoked deep unary op should succeed");
+    expect(result.value).toBe(unaryDepth * 2);
+  });
+
   test("mixed policy and fluent wrapper chain returns the correct value at depth 3_000", async () => {
     const depth = 3_000;
     let op = Op.of(0);


### PR DESCRIPTION
## Summary

Fixes #239. Deep interleaved `.with(Policy.retry(...)).map(...)` chains were stack-safe after #238 but still bound in O(n²) time because each push-through policy attach walked and rebuilt every unary wrapper above it.

`applyPlanTransforms` now tags transforms as `unaryWrap`, `pushPolicy`, or `boundary` and defers unary materialization until a boundary or the end of the fold. Policy rewrites hit the nearest non-unary base in O(1) per attach while producing the same plan tree and push-through semantics (fluent and timeout push-through suites unchanged).

## Test plan

- [x] `pnpm --filter @prodkit/op run test` (709 passed, including depth 3_000 mixed policy/fluent stack-safety)
- [x] `pnpm run gate`