### PR TITLE
normalize deep unary entry plans before stacked push-through policies

### DIFF
--- a/packages/op/CHANGELOG.md
+++ b/packages/op/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interleaved fluent transforms and push-through policies (for example
   `.with(Policy.retry(...)).map(...)`) now bind in linear time instead of quadratic time at
   `.run()` / `yield*`, with unchanged push-through semantics.
+- Stacking push-through policies on an op whose bound plan is already a deep unary chain (for
+  example after invoking a parameterized op built with many `.map(...)` layers) no longer re-walks
+  that entry depth once per policy at bind time.
 - Corrected bundle size figures in the published performance docs; the main entry is now measured
   as a bundled graph (`better-result` externalized), with a consumer subpath upper bound
   (`di`, `policy`, `hkt`).

--- a/packages/op/src/core/plan/base.ts
+++ b/packages/op/src/core/plan/base.ts
@@ -119,6 +119,30 @@ export function createUnaryPlan<T, E, M, TSource, ESource, MSource>(
   return plan;
 }
 
+/**
+ * Splits a plan's leading run of unary wrappers from its nearest non-unary node.
+ *
+ * Returned `wraps` are innermost-first, matching left-to-right application order:
+ * `wraps.reduce((plan, wrap) => wrap(plan), base)` reconstructs the input plan.
+ */
+export function splitLeadingUnaryWraps(plan: ErasedPlan): {
+  readonly base: ErasedPlan;
+  readonly wraps: ReadonlyArray<UnaryPlanRewrite["rebuild"]>;
+} {
+  const wraps: UnaryPlanRewrite["rebuild"][] = [];
+  let current = plan;
+
+  while (true) {
+    const unary = current[PLAN_UNARY_REWRITE];
+    if (unary === undefined) break;
+    wraps.push(unary.rebuild);
+    current = unary.source;
+  }
+
+  wraps.reverse();
+  return { base: current, wraps };
+}
+
 function rewritePlanStackSafe(source: ErasedPlan, rewriter: PlanRewriter): ErasedPlan {
   const rebuilds: UnaryPlanRewrite["rebuild"][] = [];
   let current = source;

--- a/packages/op/src/core/plan/shell.ts
+++ b/packages/op/src/core/plan/shell.ts
@@ -15,6 +15,7 @@ import {
   OP_PLAN_BIND,
   createPlan,
   genPlan,
+  splitLeadingUnaryWraps,
   type Plan,
   type PlanBackedOp,
   type PlanBinder,
@@ -174,12 +175,25 @@ function getPlanFactoryChain(factory: ErasedPlanFactory): PlanFactoryChain {
 
 function applyPlanTransforms(source: ErasedPlan, tail: PlanTransformNode): ErasedPlan {
   const nodes: PlanTransformNode[] = [];
+  let hasPushPolicy = false;
   for (let node: PlanTransformNode | undefined = tail; node !== undefined; node = node.previous) {
     nodes.push(node);
+    if (node.kind === "pushPolicy") hasPushPolicy = true;
   }
 
   let base = source;
   const pendingUnaryWraps: ErasedPlanTransform[] = [];
+
+  // When a push-through policy is present and the entry plan is itself a deep unary chain (for
+  // example an already-folded op reached through `getPlan`/`invoke`), split the entry plan's leading
+  // unary wrappers up front. That keeps `base` shallow so each `pushPolicy` rewrites it in O(1)
+  // instead of re-walking and rebuilding the entry chain per policy. A shallow (non-unary) entry
+  // short-circuits the split in O(1), so the common case is unaffected.
+  if (hasPushPolicy) {
+    const split = splitLeadingUnaryWraps(source);
+    base = split.base;
+    for (const wrap of split.wraps) pendingUnaryWraps.push(wrap);
+  }
 
   const materialize = () => {
     for (let index = 0; index < pendingUnaryWraps.length; index += 1) {

--- a/packages/op/tests/unit/stack-safety.test.ts
+++ b/packages/op/tests/unit/stack-safety.test.ts
@@ -47,6 +47,25 @@ describe("deep composition stack safety", () => {
     expect(result.value).toBe(depth);
   });
 
+  test("stacked policies on invoked deep unary op return the correct value", async () => {
+    const unaryDepth = 800;
+    const policyCount = 128;
+
+    let op = Op(function* (x: number) {
+      return x;
+    });
+    for (let i = 0; i < unaryDepth; i += 1) op = op.map((x) => x + 1);
+
+    let bound = op(unaryDepth);
+    for (let i = 0; i < policyCount; i += 1) {
+      bound = bound.with(Policy.retry({ retries: 0 }));
+    }
+
+    const result = await bound.run();
+    assert(result.isOk(), "stacked policies on invoked deep unary op should succeed");
+    expect(result.value).toBe(unaryDepth * 2);
+  });
+
   test("mixed policy and fluent wrapper chain returns the correct value at depth 3_000", async () => {
     const depth = 3_000;
     let op = Op.of(0);


### PR DESCRIPTION
## Summary

Fixes #240. Stacked on #241.

When push-through policies attach to an op whose bound plan is already a deep unary chain (typical after invoking a parameterized op with many `.map(...)` layers), bind time was O(d*k) because each policy re-walked the entry depth. `splitLeadingUnaryWraps` seeds the deferred fold with the entry wrappers once so each `pushPolicy` rewrites a shallow base in O(1).

## Test plan

- [x] new stack-safety regression (800 unary depth, 128 stacked retries)
- [x] `pnpm run gate` (711 op tests)