### PR TITLE
add @prodkit/op-lint for Op generator composition linting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "op-v*"
+      - "op-lint-v*"
       - "std-v*"
 
 permissions:
@@ -38,7 +39,7 @@ jobs:
           package_id="${tag%%-v*}"
 
           case "$package_id" in
-            op|std) ;;
+            op|op-lint|std) ;;
             *)
               echo "Unsupported release tag prefix: ${tag}"
               echo "allow_publish=false" >> "$GITHUB_OUTPUT"
@@ -154,6 +155,7 @@ jobs:
         run: |
           case "${{ needs.validate-publish-source.outputs.package_id }}" in
             op) echo "NPM_FILTER=@prodkit/op" >> "$GITHUB_ENV" ;;
+            op-lint) echo "NPM_FILTER=@prodkit/op-lint" >> "$GITHUB_ENV" ;;
             std) echo "NPM_FILTER=@prodkit/std" >> "$GITHUB_ENV" ;;
             *)
               echo "Unsupported package id: ${{ needs.validate-publish-source.outputs.package_id }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ pnpm install
 
 - This repository is a pnpm workspace monorepo orchestrated by Turborepo (`turbo`).
 - Root scripts (`pnpm run build|test|lint|typecheck|gate`) run across the workspace graph.
-- Publishable libraries today: **`@prodkit/op`** and **`@prodkit/std`** (see `packages/op`, `packages/std`).
+- Publishable libraries today: **`@prodkit/op`**, **`@prodkit/op-lint`**, and **`@prodkit/std`** (see `packages/op`, `packages/op-lint`, `packages/std`).
 - Supporting workspaces: **`@prodkit/shared`** (`packages/shared`, private workspace types/config), **`@prodkit/examples`** (`examples/`), **`@prodkit/tools`** (`tools/`), **`@prodkit/benchmarks`** (`benchmarks/`).
 - `@prodkit/op` landed first historically; the repo is intentionally multi-package.
 - Package-scoped scripts stay in the owning workspace `package.json`; invoke them with `pnpm --filter <workspace> run <script>`.
@@ -44,8 +44,9 @@ auto-merge).
 ## Documentation
 
 `@prodkit/op` consumer docs (`packages/op/README.md`, `packages/op/docs/`) ship on npm. They cover
-installation, API usage, and runtime semantics for library users. They do not link to monorepo-only
-material (ADRs, contributor guides, or `docs/CONTEXT.md`).
+installation, API usage, and runtime semantics for library users. `@prodkit/op-lint` consumer docs
+live in `packages/op-lint/README.md` and ship with the lint plugin package. Consumer docs do not
+link to monorepo-only material (ADRs, contributor guides, or `docs/CONTEXT.md`).
 
 Contributor and architecture docs live in the repo only:
 
@@ -84,6 +85,8 @@ and packs `@prodkit/std` even though `packages/std/src/` is effectively empty to
 tarball layout, `exports` wiring, and publish plumbing for the second npm package, not utility
 module coverage. When `@prodkit/std` subpaths ship real code, the same pack path exercises them
 without changing the gate shape.
+`@prodkit/op-lint` keeps its Oxlint JavaScript-plugin smoke coverage in package tests because it
+exercises lint loading rather than the runnable examples workspace.
 
 Pull requests and pushes to `main` and `beta/0.2.0` run the same gate in
 `.github/workflows/ci.yml`.
@@ -110,8 +113,8 @@ A `runnable-gating:check` gate step fails when Vitest coverage excludes for comp
 gating modules are removed or when stable describe/test titles for metadata blocking and DI provide
 behavior disappear from `@prodkit/op` tests (see Runnable metadata in
 [`docs/contributor/runtime-architecture.md`](docs/contributor/runtime-architecture.md)).
-A `docs:check` gate step fails when shipped consumer docs (`README.md`, `packages/op/README.md`,
-and `packages/op/docs/`) contain broken relative links, missing in-repo GitHub blob/tree targets, or
+A `docs:check` gate step fails when shipped consumer docs (`README.md`, package READMEs, and
+`packages/op/docs/`) contain broken relative links, missing in-repo GitHub blob/tree targets, or
 stale heading anchors.
 A `changelog:api:check` gate step fails when `packages/op/src/index.ts`,
 `packages/op/src/di/index.ts`, `packages/op/src/policy/index.ts`, or `packages/op/src/hkt.ts`
@@ -252,6 +255,15 @@ which doc to open for a given question.
   `@prodkit/op` keeps an external `tests/` tree instead; that difference is intentional.
 - Package docs: [`packages/std/README.md`](packages/std/README.md). Ship changelog: [`packages/std/CHANGELOG.md`](packages/std/CHANGELOG.md).
 
+## Source layout (`@prodkit/op-lint`)
+
+- Source under `packages/op-lint/src/`; the published entrypoint exports a plain
+  ESLint-compatible plugin object for Oxlint JavaScript plugin loading.
+- Rules are package-owned under `packages/op-lint/src/rules/` and tests colocate under
+  `packages/op-lint/src/**/*.test.ts`.
+- Package docs: [`packages/op-lint/README.md`](packages/op-lint/README.md). Ship changelog:
+  [`packages/op-lint/CHANGELOG.md`](packages/op-lint/CHANGELOG.md).
+
 You can run consumer install path checks directly. Each mode builds a temporary mini-pnpm workspace (reusing `catalog:` and pnpm safety policy from `pnpm-workspace.yaml`), installs `@prodkit/op` and `@prodkit/std` from the chosen source, then runs `examples/` smoke:
 
 ```bash
@@ -259,6 +271,7 @@ pnpm --filter @prodkit/tools run examples:smoke:pack
 pnpm --filter @prodkit/tools run examples:smoke:github
 pnpm --filter @prodkit/tools run examples:smoke:npm
 pnpm --filter @prodkit/op run test
+pnpm --filter @prodkit/op-lint run test
 pnpm --filter @prodkit/std run test
 ```
 
@@ -293,7 +306,7 @@ consumers, not for repo-internal implementation history.
 
 ## Release Workflow (Recommended)
 
-Publishable packages use package-scoped git tags (`op-vX.Y.Z`, `std-vX.Y.Z`).
+Publishable packages use package-scoped git tags (`op-vX.Y.Z`, `op-lint-vX.Y.Z`, `std-vX.Y.Z`).
 Pushing a tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
 which publishes the matching npm package. Legacy plain `v*` tags remain in history but
 are not used for new releases.
@@ -301,6 +314,7 @@ are not used for new releases.
 1. Keep the package changelog updated under `## [Unreleased]` as work lands:
 
    - `@prodkit/op`: `packages/op/CHANGELOG.md`
+   - `@prodkit/op-lint`: `packages/op-lint/CHANGELOG.md`
    - `@prodkit/std`: `packages/std/CHANGELOG.md`
 
    Changelogs follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) for **npm consumers** of
@@ -323,6 +337,8 @@ are not used for new releases.
 ```bash
 pnpm --filter @prodkit/op run release:patch   # patch bump
 pnpm --filter @prodkit/op run release:minor   # minor bump (for example 0.1.x -> 0.2.0)
+pnpm --filter @prodkit/op-lint run release:patch
+pnpm --filter @prodkit/op-lint run release:minor
 pnpm --filter @prodkit/std run release:patch
 ```
 
@@ -341,10 +357,11 @@ release validation runs against the tagged commit.
 
 ```bash
 pnpm --filter @prodkit/op run release:push
+pnpm --filter @prodkit/op-lint run release:push
 pnpm --filter @prodkit/std run release:push
 ```
 
-4. The workflow (for tags like `op-v0.1.70` or `std-v0.1.1`) then:
+4. The workflow (for tags like `op-v0.1.70`, `op-lint-v0.1.0`, or `std-v0.1.1`) then:
 
    - validates the tag is the latest package-scoped tag on `main`
    - verifies the `CI` workflow has passed for the tagged commit
@@ -390,4 +407,11 @@ pnpm --filter @prodkit/op publish --access public --provenance --no-git-checks
 ```bash
 pnpm --filter @prodkit/std run release:prepare
 pnpm --filter @prodkit/std publish --access public --provenance --no-git-checks
+```
+
+`@prodkit/op-lint` (after version + changelog updates):
+
+```bash
+pnpm --filter @prodkit/op-lint run release:prepare
+pnpm --filter @prodkit/op-lint publish --access public --provenance --no-git-checks
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ examples, benchmarks, and maintainer tooling.
 Use each publishable package README under `packages/*/README.md` as the source of truth for that package's installation, API reference, usage examples, and consumer-facing commands:
 
 - [`@prodkit/op`](packages/op/README.md) (published to npm with the package)
+- [`@prodkit/op-lint`](packages/op-lint/README.md) (published to npm with the package)
 - [`@prodkit/std`](packages/std/README.md) (reserved; runtime-agnostic utilities planned)
 
 Other workspace roots are maintainer- or CI-oriented: [`examples`](examples/) (`@prodkit/examples`, topic folders under `examples/op/` and `examples/op/di/`), [`tools`](tools/) (`@prodkit/tools`), and [`benchmarks`](benchmarks/) (`@prodkit/benchmarks`).
@@ -19,6 +20,7 @@ Other workspace roots are maintainer- or CI-oriented: [`examples`](examples/) (`
 | --- | --- | --- |
 | npm consumers | [`packages/op/README.md`](packages/op/README.md) | Hub, quick start, core API |
 | npm consumers | [`packages/op/docs/`](packages/op/docs/README.md) | Comparison, performance, subpaths, lifecycle (ships on npm) |
+| npm consumers | [`packages/op-lint/README.md`](packages/op-lint/README.md) | Lint plugin install and rules |
 | contributors | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Setup, gate, testing, release |
 | security | [`SECURITY.md`](SECURITY.md) | Vulnerability reporting and disclosure |
 | contributors | [`docs/CONTEXT.md`](docs/CONTEXT.md) | Domain vocabulary, doc roles, where new modules live |
@@ -26,7 +28,7 @@ Other workspace roots are maintainer- or CI-oriented: [`examples`](examples/) (`
 | contributors | [`docs/contributor/runtime-architecture.md`](docs/contributor/runtime-architecture.md) | Module graph and execution flow |
 | architects | [`docs/adr/`](docs/adr/) | Why decisions were made |
 
-Changelogs: [`packages/op/CHANGELOG.md`](packages/op/CHANGELOG.md), [`packages/std/CHANGELOG.md`](packages/std/CHANGELOG.md).
+Changelogs: [`packages/op/CHANGELOG.md`](packages/op/CHANGELOG.md), [`packages/op-lint/CHANGELOG.md`](packages/op-lint/CHANGELOG.md), [`packages/std/CHANGELOG.md`](packages/std/CHANGELOG.md).
 
 ## workspace layout
 
@@ -50,7 +52,7 @@ pnpm run gate
 
 ## release flow
 
-Pushing a package-scoped tag (`op-v*`, `std-v*`) triggers
+Pushing a package-scoped tag (`op-v*`, `op-lint-v*`, `std-v*`) triggers
 [`.github/workflows/release.yml`](.github/workflows/release.yml), which publishes the matching
 npm package with trusted publishing and provenance. Release helpers live on each publishable
 package:
@@ -58,6 +60,9 @@ package:
 ```bash
 pnpm --filter @prodkit/op run release:patch   # or release:minor
 pnpm --filter @prodkit/op run release:push
+
+pnpm --filter @prodkit/op-lint run release:patch   # or release:minor
+pnpm --filter @prodkit/op-lint run release:push
 
 pnpm --filter @prodkit/std run release:patch
 pnpm --filter @prodkit/std run release:push

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -8,6 +8,7 @@ right doc before diving into code.
 | Package | Role |
 | --- | --- |
 | `@prodkit/op` | Runtime-agnostic operation library: typed async composition, policies, combinators, DI subpath |
+| `@prodkit/op-lint` | Oxlint-loadable lint rules for `@prodkit/op` generator composition |
 | `@prodkit/std` | Reserved runtime-agnostic utilities (no `@prodkit/op` dependency); example subpath `@prodkit/std/array` |
 | `@prodkit/shared` | Private workspace globals, publishable tsconfig/vitest presets, and runtime primitives (not published) |
 | `@prodkit/examples` | Consumer smoke and sample apps |
@@ -23,6 +24,7 @@ exports, not separate npm packages or `@prodkit/std` modules. Full placement rul
 | Path | Workspace | Audience |
 | --- | --- | --- |
 | `packages/op/` | `@prodkit/op` | Published operation runtime and subpaths |
+| `packages/op-lint/` | `@prodkit/op-lint` | Published lint plugin for Op usage |
 | `packages/std/` | `@prodkit/std` | Published utilities with no `@prodkit/op` dependency |
 | `packages/shared/` | `@prodkit/shared` | Private presets and workspace primitives (not on npm) |
 | `examples/` | `@prodkit/examples` | Consumer samples and smoke; layout in `examples/README.md`, topic index in `examples/op/README.md` |
@@ -40,6 +42,7 @@ Use this table when adding a feature. Rationale and examples:
 | Situation | Home |
 | --- | --- |
 | Builds on `Op`, plans, policies, or DI; runtime-agnostic; depends only on `@prodkit/op` and `better-result` (existing op peer) | `@prodkit/op/<subpath>` (for example `@prodkit/op/policy` for a circuit-breaker policy) |
+| Lint rules or lint-plugin integration for Op usage | `@prodkit/op-lint` |
 | Runtime-agnostic utilities that do not import `@prodkit/op` | `@prodkit/std/<subpath>` (for example `@prodkit/std/array`) |
 | Platform-specific (Node-only CLI adapter, DOM-only helper) | New `@prodkit/*` package under `packages/` |
 | Hard dependency on an integration SDK (OpenTelemetry, a validation stack, an HTTP framework) | New `@prodkit/*` package under `packages/` |
@@ -73,6 +76,7 @@ the boundary choice is not already covered by ADR 0008.
 | Question | Start here |
 | --- | --- |
 | How do I install and use `@prodkit/op`? | [`packages/op/README.md`](../packages/op/README.md) (hub + core API; ships on npm) |
+| How do I lint `@prodkit/op` generator usage? | [`packages/op-lint/README.md`](../packages/op-lint/README.md) (ships on npm) |
 | Subpaths, lifecycle, cancellation depth | [`packages/op/docs/`](../packages/op/docs/README.md) (ships on npm) |
 | Why was it built this way? | [`docs/adr/README.md`](adr/README.md) (monorepo only) |
 | How does execution flow through modules? | [`docs/contributor/runtime-architecture.md`](contributor/runtime-architecture.md) |
@@ -83,7 +87,7 @@ the boundary choice is not already covered by ADR 0008.
 | How should durable docs be written? | [Evergreen writing](#evergreen-writing) (this file) |
 | How does `@prodkit/op` compare to Effect / neverthrow? | [`packages/op/docs/comparison.md`](../packages/op/docs/comparison.md) (ships on npm) |
 | What is the runtime overhead? | [`packages/op/docs/performance.md`](../packages/op/docs/performance.md) (ships on npm) |
-| What changed in the last release? | Package `CHANGELOG.md` under `packages/op` or `packages/std` |
+| What changed in the last release? | Package `CHANGELOG.md` under `packages/op`, `packages/op-lint`, or `packages/std` |
 
 ## Documentation boundaries
 

--- a/packages/op-lint/CHANGELOG.md
+++ b/packages/op-lint/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect ignored `@prodkit/op` values in `require-yield-star` with TypeScript checker-backed
   identity, including aliases, imports, generic `Op` parameters, properties, and methods returning
   Ops.
+- Report returned, yielded, and awaited `@prodkit/op` values in `require-yield-star`, with autofixes
+  for direct rewrites to `yield*`.
 
 ### Changed
 

--- a/packages/op-lint/CHANGELOG.md
+++ b/packages/op-lint/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Publish the initial ESLint-compatible, Oxlint-loadable `@prodkit/op-lint` plugin package with the
   `require-yield-star` rule scaffold.
+- Detect ignored `@prodkit/op` values in `require-yield-star` with TypeScript checker-backed
+  identity, including aliases, imports, generic `Op` parameters, properties, and methods returning
+  Ops.
+
+### Changed
+
+- Keep TypeScript external and require it as a peer dependency for checker-backed linting.
 
 ## [0.0.0]
 

--- a/packages/op-lint/CHANGELOG.md
+++ b/packages/op-lint/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Publish the initial ESLint-compatible, Oxlint-loadable `@prodkit/op-lint` plugin package with the
+  `require-yield-star` rule scaffold.
+
+## [0.0.0]
+
+### Added
+
+- Establish the unpublished package baseline for release tooling.

--- a/packages/op-lint/CHANGELOG.md
+++ b/packages/op-lint/CHANGELOG.md
@@ -20,9 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Keep TypeScript external and require it as a peer dependency for checker-backed linting.
-
-## [0.0.0]
-
-### Added
-
-- Establish the unpublished package baseline for release tooling.
+- Overhaul the `@prodkit/op-lint` README around common Op generator mistakes, Oxlint setup, ESLint
+  setup, and checker-backed detection limits.

--- a/packages/op-lint/LICENSE
+++ b/packages/op-lint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Travis Wagner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/op-lint/README.md
+++ b/packages/op-lint/README.md
@@ -1,8 +1,46 @@
 # @prodkit/op-lint
 
-Lint rules for `@prodkit/op` generator composition. The package exports a plain
-ESLint-compatible plugin object and can be loaded by Oxlint through JavaScript plugins.
-Compatibility is tested against ESLint RuleTester and Oxlint JavaScript plugin loading.
+Catches the most common `@prodkit/op` mistakes before they turn into runtime bugs. The plugin
+works in both Oxlint and ESLint, with the same rule name in either linter.
+
+## Why use it
+
+Inside an `Op(function* () { ... })` body, a child Op runs when it is composed with `yield*`. The
+easy mistakes all look valid to TypeScript but do the wrong thing for Op composition:
+
+```ts
+import { Op } from "@prodkit/op";
+
+const ignored = Op(function* () {
+  Op.of(1);
+});
+
+const returned = Op(function* () {
+  return Op.of(1);
+});
+
+const yielded = Op(function* () {
+  yield Op.of(1);
+});
+
+const awaited = Op(async function* () {
+  await Op.of(1);
+});
+```
+
+`@prodkit/op-lint` reports those patterns and, when the rewrite is mechanical, can fix them to
+`yield*`.
+
+```ts
+import { Op } from "@prodkit/op";
+
+const valid = Op(function* () {
+  const value = yield* Op.of(1);
+  const staged = Op.of(value + 1);
+
+  return yield* staged;
+});
+```
 
 ## Install
 
@@ -10,7 +48,12 @@ Compatibility is tested against ESLint RuleTester and Oxlint JavaScript plugin l
 pnpm add -D @prodkit/op-lint oxlint typescript
 ```
 
-## Oxlint
+`typescript` is a peer dependency because the rule uses the TypeScript checker to recognize real
+`@prodkit/op` values.
+
+## Use with Oxlint
+
+Add the package as an Oxlint JavaScript plugin and enable `prodkit-op/require-yield-star`.
 
 ```json
 {
@@ -26,28 +69,73 @@ pnpm add -D @prodkit/op-lint oxlint typescript
 }
 ```
 
-Oxlint JavaScript plugins are alpha in Oxlint. Keep the plugin and Oxlint versions tested together
-when upgrading.
-
-## Rules
-
-### `require-yield-star`
-
-Reports `Op`-typed expressions inside generator bodies when the returned operation is not composed
-with `yield*`.
+The same setup works in `oxlint.config.ts`:
 
 ```ts
-import { Op } from "@prodkit/op";
+import { defineConfig } from "oxlint";
 
-const invalid = Op(function* () {
-  Op.of(1);
-});
-
-const valid = Op(function* () {
-  return yield* Op.of(1);
+export default defineConfig({
+  jsPlugins: [
+    {
+      name: "prodkit-op",
+      specifier: "@prodkit/op-lint",
+    },
+  ],
+  rules: {
+    "prodkit-op/require-yield-star": "error",
+  },
 });
 ```
 
-The rule uses TypeScript checker information to recognize `@prodkit/op` values, including aliases,
-imported operations, generic `Op` parameters, properties, and methods returning Ops. When type
-information is unavailable, it still catches direct `Op.<builder>(...)` expression statements.
+Oxlint JavaScript plugins are alpha in Oxlint, so keep plugin and Oxlint upgrades tested together.
+
+## Use with ESLint
+
+ESLint flat config can load the same package as a normal plugin object.
+
+```js
+import prodkitOp from "@prodkit/op-lint";
+
+export default [
+  {
+    plugins: {
+      "prodkit-op": prodkitOp,
+    },
+    rules: {
+      "prodkit-op/require-yield-star": "error",
+    },
+  },
+];
+```
+
+## Rule behavior
+
+### `prodkit-op/require-yield-star`
+
+Reports Op values inside generator bodies when they are not composed with `yield*`.
+
+The rule reports:
+
+- Direct Op expression statements, such as `Op.of(1);`
+- Returned Ops, such as `return loadUser();`
+- Non-delegating yields, such as `yield loadUser();`
+- Awaited Ops, such as `await loadUser();`
+
+The rule allows:
+
+- `return yield* loadUser();`
+- Staging an Op in a local variable before later `yield*` composition
+- Ops returned from non-generator callbacks
+- Non-Op iterables and structural lookalikes that do not come from `@prodkit/op`
+
+## Type detection
+
+The rule detects direct `Op.<builder>(...)` calls even without checker information. With TypeScript
+resolution available, it also recognizes aliases, imported operations, generic `Op` parameters,
+properties typed as Ops, and methods returning Ops.
+
+The detector is conservative. Type-aware matches require TypeScript to resolve the linted file and
+`@prodkit/op` from the nearest `tsconfig.json`; without a config, the plugin falls back to an
+inferred NodeNext project. Expressions typed as `any` or `unknown` are not reported from type
+information, and objects that merely look like Ops are ignored unless their Op identity comes from
+`@prodkit/op`.

--- a/packages/op-lint/README.md
+++ b/packages/op-lint/README.md
@@ -1,0 +1,52 @@
+# @prodkit/op-lint
+
+Lint rules for `@prodkit/op` generator composition. The package exports a plain
+ESLint-compatible plugin object and can be loaded by Oxlint through JavaScript plugins.
+Compatibility is tested against ESLint RuleTester and Oxlint JavaScript plugin loading.
+
+## Install
+
+```bash
+pnpm add -D @prodkit/op-lint oxlint
+```
+
+## Oxlint
+
+```json
+{
+  "jsPlugins": [
+    {
+      "name": "prodkit-op",
+      "specifier": "@prodkit/op-lint"
+    }
+  ],
+  "rules": {
+    "prodkit-op/require-yield-star": "error"
+  }
+}
+```
+
+Oxlint JavaScript plugins are alpha in Oxlint. Keep the plugin and Oxlint versions tested together
+when upgrading.
+
+## Rules
+
+### `require-yield-star`
+
+Reports direct calls to known `Op` builders inside generator bodies when the returned operation is
+not composed with `yield*`.
+
+```ts
+import { Op } from "@prodkit/op";
+
+const invalid = Op(function* () {
+  Op.of(1);
+});
+
+const valid = Op(function* () {
+  return yield* Op.of(1);
+});
+```
+
+The rule is syntax-only: it catches direct `Op.<builder>(...)` expression statements in generator
+functions. It does not do type-aware import, alias, or custom builder analysis.

--- a/packages/op-lint/README.md
+++ b/packages/op-lint/README.md
@@ -7,7 +7,7 @@ Compatibility is tested against ESLint RuleTester and Oxlint JavaScript plugin l
 ## Install
 
 ```bash
-pnpm add -D @prodkit/op-lint oxlint
+pnpm add -D @prodkit/op-lint oxlint typescript
 ```
 
 ## Oxlint
@@ -33,8 +33,8 @@ when upgrading.
 
 ### `require-yield-star`
 
-Reports direct calls to known `Op` builders inside generator bodies when the returned operation is
-not composed with `yield*`.
+Reports `Op`-typed expressions inside generator bodies when the returned operation is not composed
+with `yield*`.
 
 ```ts
 import { Op } from "@prodkit/op";
@@ -48,5 +48,6 @@ const valid = Op(function* () {
 });
 ```
 
-The rule is syntax-only: it catches direct `Op.<builder>(...)` expression statements in generator
-functions. It does not do type-aware import, alias, or custom builder analysis.
+The rule uses TypeScript checker information to recognize `@prodkit/op` values, including aliases,
+imported operations, generic `Op` parameters, properties, and methods returning Ops. When type
+information is unavailable, it still catches direct `Op.<builder>(...)` expression statements.

--- a/packages/op-lint/package.json
+++ b/packages/op-lint/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@prodkit/op-lint",
+  "version": "0.0.0",
+  "description": "Oxlint-loadable lint rules for @prodkit/op generator composition.",
+  "keywords": [
+    "eslint",
+    "lint",
+    "operations",
+    "oxlint",
+    "prodkit",
+    "typescript"
+  ],
+  "homepage": "https://github.com/trvswgnr/prodkit/tree/main/packages/op-lint#readme",
+  "bugs": {
+    "url": "https://github.com/trvswgnr/prodkit/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trvswgnr/prodkit"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "fix": "pnpm run lint:fix && pnpm run fmt",
+    "fmt": "oxfmt \"src/**/*.ts\" \"*.ts\"",
+    "fmt:check": "oxfmt --check \"src/**/*.ts\" \"*.ts\"",
+    "lint": "pnpm -w exec oxlint --config oxlint.config.ts packages/op-lint/src",
+    "lint:fix": "pnpm -w exec oxlint --config oxlint.config.ts --fix packages/op-lint/src",
+    "changelog:check": "pnpm --filter @prodkit/tools run changelog:check op-lint",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm -w run gate && pnpm run changelog:check",
+    "release:prepare": "pnpm -w run gate && pnpm run changelog:check && npm pack --dry-run",
+    "release:patch": "pnpm --filter @prodkit/tools run release:cut op-lint patch",
+    "release:minor": "pnpm --filter @prodkit/tools run release:cut op-lint minor",
+    "release:publish:manual": "npm publish --access public --provenance",
+    "release:push": "git push && git push --tags",
+    "coverage": "vitest run --coverage",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@prodkit/shared": "workspace:*",
+    "@types/node": "^24.12.2",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "10.5.0",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/op-lint/package.json
+++ b/packages/op-lint/package.json
@@ -38,6 +38,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "typescript": ">=5.9 <7"
+  },
   "scripts": {
     "build": "tsdown",
     "fix": "pnpm run lint:fix && pnpm run fmt",

--- a/packages/op-lint/src/index.test.ts
+++ b/packages/op-lint/src/index.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -20,18 +20,31 @@ describe("@prodkit/op-lint plugin", () => {
     );
   });
 
-  test("loads through Oxlint JavaScript plugins and reports a direct misuse", () => {
+  test("loads through Oxlint JavaScript plugins and reports direct and typed misuses", () => {
     const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
     const repoRoot = resolve(packageRoot, "../..");
     const distEntry = resolve(packageRoot, "dist/index.mjs");
     const oxlintBin = resolve(repoRoot, "node_modules/oxlint/bin/oxlint");
+    const opPackageRoot = resolve(packageRoot, "../op");
+    const betterResultRoot = resolve(opPackageRoot, "node_modules/better-result");
 
     expect(existsSync(distEntry), `${distEntry} should exist before the smoke test`).toBe(true);
     expect(existsSync(oxlintBin), `${oxlintBin} should exist before the smoke test`).toBe(true);
+    expect(existsSync(opPackageRoot), `${opPackageRoot} should exist before the smoke test`).toBe(
+      true,
+    );
+    expect(
+      existsSync(betterResultRoot),
+      `${betterResultRoot} should exist before the smoke test`,
+    ).toBe(true);
 
     const tempDir = mkdtempSync(resolve(tmpdir(), "prodkit-op-lint-"));
 
     try {
+      mkdirSync(resolve(tempDir, "node_modules/@prodkit"), { recursive: true });
+      symlinkSync(opPackageRoot, resolve(tempDir, "node_modules/@prodkit/op"), "dir");
+      symlinkSync(betterResultRoot, resolve(tempDir, "node_modules/better-result"), "dir");
+
       writeFileSync(
         resolve(tempDir, "plugin.mjs"),
         `export { default } from ${JSON.stringify(pathToFileURL(distEntry).href)};\n`,
@@ -52,16 +65,70 @@ describe("@prodkit/op-lint plugin", () => {
         "utf8",
       );
       writeFileSync(
-        resolve(tempDir, "fixture.ts"),
+        resolve(tempDir, "tsconfig.json"),
+        `${JSON.stringify(
+          {
+            compilerOptions: {
+              module: "NodeNext",
+              moduleResolution: "NodeNext",
+              skipLibCheck: true,
+              strict: true,
+              target: "ES2022",
+            },
+            include: ["*.ts"],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      writeFileSync(
+        resolve(tempDir, "ops.ts"),
         [
           'import { Op } from "@prodkit/op";',
           "",
+          'export const importedOperation = Op.of("ok");',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(
+        resolve(tempDir, "fixture.ts"),
+        [
+          'import { Op, type Op as OpType } from "@prodkit/op";',
+          'import { importedOperation } from "./ops.js";',
+          "",
+          "const direct = Op.of(1);",
+          "const alias = direct;",
+          "",
+          "declare const service: {",
+          "  readonly stored: OpType<boolean, never, []>;",
+          "  load(): OpType<number, never, []>;",
+          "};",
+          "",
+          "function generic<T extends OpType<number, never, []>>(op: T) {",
+          "  return Op(function* () {",
+          "    op;",
+          "  });",
+          "}",
+          "",
+          "const iterable = { *[Symbol.iterator]() { yield 1; return 1; } };",
+          'const lookalike = { _tag: "Op", run() {}, with() {}, on() {}, map() {}, mapErr() {}, flatMap() {}, tap() {}, tapErr() {}, recover() {} };',
+          "",
           "const program = Op(function* () {",
           "  Op.of(1);",
+          "  direct;",
+          "  alias;",
+          "  importedOperation;",
+          "  service.stored;",
+          "  service.load();",
+          "  iterable;",
+          "  lookalike;",
           "  return yield* Op.of(2);",
           "});",
           "",
           "void program;",
+          "void generic(direct);",
           "",
         ].join("\n"),
         "utf8",
@@ -78,7 +145,23 @@ describe("@prodkit/op-lint plugin", () => {
       const output = `${result.stdout}\n${result.stderr}`;
 
       expect(result.status, output).toBe(1);
-      expect(output).toContain("prodkit-op(require-yield-star)");
+      const outputJson = JSON.parse(result.stdout);
+      const diagnostics: unknown[] =
+        typeof outputJson === "object" &&
+        outputJson !== null &&
+        "diagnostics" in outputJson &&
+        Array.isArray(outputJson.diagnostics)
+          ? outputJson.diagnostics
+          : [];
+      const opDiagnostics = diagnostics.filter(
+        (diagnostic) =>
+          typeof diagnostic === "object" &&
+          diagnostic !== null &&
+          "code" in diagnostic &&
+          diagnostic.code === "prodkit-op(require-yield-star)",
+      );
+
+      expect(opDiagnostics).toHaveLength(7);
       expect(output).toContain("Compose this Op with yield*");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/packages/op-lint/src/index.test.ts
+++ b/packages/op-lint/src/index.test.ts
@@ -127,7 +127,22 @@ describe("@prodkit/op-lint plugin", () => {
           "  return yield* Op.of(2);",
           "});",
           "",
+          "const returned = Op(function* () {",
+          "  return direct;",
+          "});",
+          "",
+          "const yielded = Op(function* () {",
+          "  yield direct;",
+          "});",
+          "",
+          "const awaited = Op(async function* () {",
+          "  await service.load();",
+          "});",
+          "",
           "void program;",
+          "void returned;",
+          "void yielded;",
+          "void awaited;",
           "void generic(direct);",
           "",
         ].join("\n"),
@@ -161,7 +176,7 @@ describe("@prodkit/op-lint plugin", () => {
           diagnostic.code === "prodkit-op(require-yield-star)",
       );
 
-      expect(opDiagnostics).toHaveLength(7);
+      expect(opDiagnostics).toHaveLength(10);
       expect(output).toContain("Compose this Op with yield*");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -176,11 +191,36 @@ describe("@prodkit/op-lint plugin", () => {
   }).run("require-yield-star", requireYieldStarRule, {
     valid: [
       "const program = Op(function* () { return yield* Op.of(1); });",
+      "const program = Op(function* () { const staged = Op.of(1); return yield* staged; });",
+      "const program = Op(function* () { items.map(() => Op.of(1)); });",
+      "const program = Op(function* () { items.map(() => { return Op.of(1); }); });",
       "function notAnOpGenerator() { Op.of(1); }",
+      "function notAGeneratorCallback() { return Op.of(1); }",
     ],
     invalid: [
       {
         code: "const program = Op(function* () { Op.of(1); });",
+        output: "const program = Op(function* () { yield* Op.of(1); });",
+        errors: [{ messageId: "missingYieldStar" }],
+      },
+      {
+        code: "const program = Op(function* () { return Op.of(1); });",
+        output: "const program = Op(function* () { return yield* Op.of(1); });",
+        errors: [{ messageId: "missingYieldStar" }],
+      },
+      {
+        code: "const program = Op(function* () { yield Op.of(1); });",
+        output: "const program = Op(function* () { yield* Op.of(1); });",
+        errors: [{ messageId: "missingYieldStar" }],
+      },
+      {
+        code: "const program = Op(async function* () { await Op.of(1); });",
+        output: "const program = Op(async function* () { yield* Op.of(1); });",
+        errors: [{ messageId: "missingYieldStar" }],
+      },
+      {
+        code: "const program = Op(async function* () { return await Op.of(1); });",
+        output: "const program = Op(async function* () { return yield* Op.of(1); });",
         errors: [{ messageId: "missingYieldStar" }],
       },
     ],

--- a/packages/op-lint/src/index.test.ts
+++ b/packages/op-lint/src/index.test.ts
@@ -1,0 +1,108 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { RuleTester } from "eslint";
+import { describe, expect, test } from "vitest";
+import { plugin as opLintPlugin, requireYieldStarRule } from "./index.js";
+
+RuleTester.describe = describe;
+RuleTester.it = test;
+
+describe("@prodkit/op-lint plugin", () => {
+  test("exports the require-yield-star rule with documentation metadata", () => {
+    expect(opLintPlugin.meta.name).toBe("@prodkit/op-lint");
+    expect(opLintPlugin.rules["require-yield-star"]).toBe(requireYieldStarRule);
+    expect(requireYieldStarRule.meta.messages.missingYieldStar).toContain("yield*");
+    expect(requireYieldStarRule.meta.docs.url).toBe(
+      "https://github.com/trvswgnr/prodkit/tree/main/packages/op-lint#require-yield-star",
+    );
+  });
+
+  test("loads through Oxlint JavaScript plugins and reports a direct misuse", () => {
+    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const repoRoot = resolve(packageRoot, "../..");
+    const distEntry = resolve(packageRoot, "dist/index.mjs");
+    const oxlintBin = resolve(repoRoot, "node_modules/oxlint/bin/oxlint");
+
+    expect(existsSync(distEntry), `${distEntry} should exist before the smoke test`).toBe(true);
+    expect(existsSync(oxlintBin), `${oxlintBin} should exist before the smoke test`).toBe(true);
+
+    const tempDir = mkdtempSync(resolve(tmpdir(), "prodkit-op-lint-"));
+
+    try {
+      writeFileSync(
+        resolve(tempDir, "plugin.mjs"),
+        `export { default } from ${JSON.stringify(pathToFileURL(distEntry).href)};\n`,
+        "utf8",
+      );
+      writeFileSync(
+        resolve(tempDir, ".oxlintrc.json"),
+        `${JSON.stringify(
+          {
+            jsPlugins: [{ name: "prodkit-op", specifier: "./plugin.mjs" }],
+            rules: {
+              "prodkit-op/require-yield-star": "error",
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      writeFileSync(
+        resolve(tempDir, "fixture.ts"),
+        [
+          'import { Op } from "@prodkit/op";',
+          "",
+          "const program = Op(function* () {",
+          "  Op.of(1);",
+          "  return yield* Op.of(2);",
+          "});",
+          "",
+          "void program;",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [oxlintBin, "--config", ".oxlintrc.json", "--format", "json", "fixture.ts"],
+        {
+          cwd: tempDir,
+          encoding: "utf8",
+        },
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("prodkit-op(require-yield-star)");
+      expect(output).toContain("Compose this Op with yield*");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  new RuleTester({
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+  }).run("require-yield-star", requireYieldStarRule, {
+    valid: [
+      "const program = Op(function* () { return yield* Op.of(1); });",
+      "function notAnOpGenerator() { Op.of(1); }",
+    ],
+    invalid: [
+      {
+        code: "const program = Op(function* () { Op.of(1); });",
+        errors: [{ messageId: "missingYieldStar" }],
+      },
+    ],
+    assertionOptions: {
+      requireMessage: "messageId",
+    },
+  });
+});

--- a/packages/op-lint/src/index.test.ts
+++ b/packages/op-lint/src/index.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -178,6 +186,137 @@ describe("@prodkit/op-lint plugin", () => {
 
       expect(opDiagnostics).toHaveLength(10);
       expect(output).toContain("Compose this Op with yield*");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("loads through ESLint flat config and applies fixes", () => {
+    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const distEntry = resolve(packageRoot, "dist/index.mjs");
+    const eslintBin = resolve(packageRoot, "node_modules/eslint/bin/eslint.js");
+    const opPackageRoot = resolve(packageRoot, "../op");
+    const betterResultRoot = resolve(opPackageRoot, "node_modules/better-result");
+
+    expect(existsSync(distEntry), `${distEntry} should exist before the smoke test`).toBe(true);
+    expect(existsSync(eslintBin), `${eslintBin} should exist before the smoke test`).toBe(true);
+    expect(existsSync(opPackageRoot), `${opPackageRoot} should exist before the smoke test`).toBe(
+      true,
+    );
+    expect(
+      existsSync(betterResultRoot),
+      `${betterResultRoot} should exist before the smoke test`,
+    ).toBe(true);
+
+    const tempDir = mkdtempSync(resolve(tmpdir(), "prodkit-op-lint-eslint-"));
+    const fixturePath = resolve(tempDir, "fixture.js");
+
+    try {
+      mkdirSync(resolve(tempDir, "node_modules/@prodkit"), { recursive: true });
+      symlinkSync(opPackageRoot, resolve(tempDir, "node_modules/@prodkit/op"), "dir");
+      symlinkSync(betterResultRoot, resolve(tempDir, "node_modules/better-result"), "dir");
+
+      writeFileSync(
+        resolve(tempDir, "eslint.config.mjs"),
+        [
+          `import prodkitOp from ${JSON.stringify(pathToFileURL(distEntry).href)};`,
+          "",
+          "export default [",
+          "  {",
+          '    files: ["**/*.js"],',
+          "    languageOptions: {",
+          '      ecmaVersion: "latest",',
+          '      sourceType: "module",',
+          "    },",
+          "    plugins: {",
+          '      "prodkit-op": prodkitOp,',
+          "    },",
+          "    rules: {",
+          '      "prodkit-op/require-yield-star": "error",',
+          "    },",
+          "  },",
+          "];",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(
+        resolve(tempDir, "tsconfig.json"),
+        `${JSON.stringify(
+          {
+            compilerOptions: {
+              allowJs: true,
+              module: "NodeNext",
+              moduleResolution: "NodeNext",
+              skipLibCheck: true,
+              strict: true,
+              target: "ES2022",
+            },
+            include: ["*.js"],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      writeFileSync(
+        fixturePath,
+        [
+          'import { Op } from "@prodkit/op";',
+          "",
+          "const direct = Op.of(1);",
+          "",
+          "const program = Op(function* () {",
+          "  Op.of(1);",
+          "  return direct;",
+          "});",
+          "",
+          "void program;",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const reportResult = spawnSync(
+        process.execPath,
+        [eslintBin, "--format", "json", fixturePath],
+        {
+          cwd: tempDir,
+          encoding: "utf8",
+        },
+      );
+      const reportOutput = `${reportResult.stdout}\n${reportResult.stderr}`;
+
+      expect(reportResult.status, reportOutput).toBe(1);
+      const reportJson = JSON.parse(reportResult.stdout);
+      const messages: unknown[] =
+        Array.isArray(reportJson) &&
+        reportJson[0] !== undefined &&
+        typeof reportJson[0] === "object" &&
+        reportJson[0] !== null &&
+        "messages" in reportJson[0] &&
+        Array.isArray(reportJson[0].messages)
+          ? reportJson[0].messages
+          : [];
+
+      expect(messages).toHaveLength(2);
+      expect(reportOutput).toContain("prodkit-op/require-yield-star");
+
+      const fixResult = spawnSync(process.execPath, [eslintBin, "--fix", fixturePath], {
+        cwd: tempDir,
+        encoding: "utf8",
+      });
+      const fixOutput = `${fixResult.stdout}\n${fixResult.stderr}`;
+
+      expect(fixResult.status, fixOutput).toBe(0);
+      expect(readFileSync(fixturePath, "utf8")).toContain(
+        [
+          "const program = Op(function* () {",
+          "  yield* Op.of(1);",
+          "  return yield* direct;",
+          "});",
+        ].join("\n"),
+      );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/packages/op-lint/src/index.ts
+++ b/packages/op-lint/src/index.ts
@@ -1,0 +1,16 @@
+import { requireYieldStarRule } from "./rules/require-yield-star.js";
+
+export { requireYieldStarRule } from "./rules/require-yield-star.js";
+
+export const rules = {
+  "require-yield-star": requireYieldStarRule,
+};
+
+export const plugin = {
+  meta: {
+    name: "@prodkit/op-lint",
+  },
+  rules,
+};
+
+export default plugin;

--- a/packages/op-lint/src/op-type-detector.ts
+++ b/packages/op-lint/src/op-type-detector.ts
@@ -1,0 +1,451 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
+import { isRecordLike } from "@prodkit/shared/runtime";
+import * as ts from "typescript";
+
+const prodkitOpPackageName = "@prodkit/op";
+const tsConfigFileName = "tsconfig.json";
+
+export type TypeAwareRuleContext = {
+  cwd?: string;
+  filename?: string;
+  physicalFilename?: string;
+  sourceCode?: unknown;
+};
+
+export type RangedNode = {
+  range: readonly [number, number];
+};
+
+export type OpTypeDetector = {
+  isOpExpression(node: RangedNode): boolean;
+};
+
+type TypeScriptProject = {
+  checker: ts.TypeChecker;
+  program: ts.Program;
+  sourceFileIndexes: WeakMap<ts.SourceFile, SourceFileIndex>;
+};
+
+type SourceFileIndex = {
+  byRange: Map<string, ts.Node[]>;
+};
+
+type SourceOverride = {
+  fileName: string;
+  text: string;
+};
+
+const projectCache = new Map<string, TypeScriptProject>();
+const packageNameCache = new Map<string, string | undefined>();
+const canonicalPathCache = new Map<string, string>();
+
+export function clearOpTypeDetectorCaches(): void {
+  projectCache.clear();
+  packageNameCache.clear();
+  canonicalPathCache.clear();
+}
+
+export function createOpTypeDetector(context: TypeAwareRuleContext): OpTypeDetector | undefined {
+  const fileName = resolveLintFileName(context);
+  if (fileName === undefined) return undefined;
+
+  const project = getTypeScriptProject(fileName, sourceTextFromContext(context));
+  if (project === undefined) return undefined;
+
+  const sourceFile = getProjectSourceFile(project.program, fileName);
+  if (sourceFile === undefined) return undefined;
+
+  return {
+    isOpExpression(node) {
+      const tsNode = findTypeScriptNodeAtRange(project, sourceFile, node.range);
+      if (tsNode === undefined) return false;
+
+      return isProdkitOpType(project.checker, project.checker.getTypeAtLocation(tsNode));
+    },
+  };
+}
+
+function sourceTextFromContext(context: TypeAwareRuleContext): string | undefined {
+  const sourceCode = context.sourceCode;
+  if (!isRecordLike(sourceCode)) return undefined;
+
+  const text = sourceCode["text"];
+  return typeof text === "string" ? text : undefined;
+}
+
+function resolveLintFileName(context: TypeAwareRuleContext): string | undefined {
+  const rawFileName = context.physicalFilename ?? context.filename;
+  if (rawFileName === undefined || rawFileName.startsWith("<")) return undefined;
+
+  const cwd = context.cwd ?? process.cwd();
+  return isAbsolute(rawFileName) ? normalize(rawFileName) : normalize(resolve(cwd, rawFileName));
+}
+
+function getTypeScriptProject(
+  fileName: string,
+  sourceText: string | undefined,
+): TypeScriptProject | undefined {
+  const configPath = ts.findConfigFile(dirname(fileName), ts.sys.fileExists, tsConfigFileName);
+  const sourceOverride = createSourceOverride(fileName, sourceText);
+
+  if (configPath === undefined) {
+    return getInferredProject(fileName, sourceOverride);
+  }
+
+  const parsedConfig = parseConfig(configPath);
+  if (parsedConfig === undefined) {
+    return getInferredProject(fileName, sourceOverride);
+  }
+
+  const canonicalFileName = canonicalPath(fileName);
+  const parsedFileNames = new Set(parsedConfig.fileNames.map(canonicalPath));
+  const fileIsInConfig = parsedFileNames.has(canonicalFileName);
+  const rootNames = fileIsInConfig ? parsedConfig.fileNames : [...parsedConfig.fileNames, fileName];
+  const options = normalizeCompilerOptions(parsedConfig.options);
+  const cacheKey = [
+    "config",
+    canonicalPath(configPath),
+    fileIsInConfig ? "included" : canonicalFileName,
+    sourceOverride === undefined ? "disk" : sourceOverrideCacheKey(sourceOverride),
+  ].join(":");
+
+  return getCachedProject(cacheKey, rootNames, options, sourceOverride);
+}
+
+function getInferredProject(
+  fileName: string,
+  sourceOverride: SourceOverride | undefined,
+): TypeScriptProject {
+  const options = normalizeCompilerOptions({
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  });
+  const cacheKey = [
+    "inferred",
+    canonicalPath(fileName),
+    sourceOverride === undefined ? "disk" : sourceOverrideCacheKey(sourceOverride),
+  ].join(":");
+
+  return getCachedProject(cacheKey, [fileName], options, sourceOverride);
+}
+
+function createSourceOverride(
+  fileName: string,
+  sourceText: string | undefined,
+): SourceOverride | undefined {
+  if (sourceText === undefined || existsSync(fileName)) return undefined;
+
+  return { fileName, text: sourceText };
+}
+
+function sourceOverrideCacheKey(sourceOverride: SourceOverride): string {
+  return `${canonicalPath(sourceOverride.fileName)}:${sourceOverride.text.length}`;
+}
+
+function parseConfig(configPath: string): ts.ParsedCommandLine | undefined {
+  return ts.getParsedCommandLineOfConfigFile(
+    configPath,
+    {},
+    {
+      ...ts.sys,
+      onUnRecoverableConfigFileDiagnostic() {},
+    },
+  );
+}
+
+function normalizeCompilerOptions(options: ts.CompilerOptions): ts.CompilerOptions {
+  return {
+    ...options,
+    allowJs: true,
+    noEmit: true,
+  };
+}
+
+function getCachedProject(
+  cacheKey: string,
+  rootNames: readonly string[],
+  options: ts.CompilerOptions,
+  sourceOverride: SourceOverride | undefined,
+): TypeScriptProject {
+  const cached = projectCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const host = createCompilerHost(options, sourceOverride);
+  const program = ts.createProgram([...rootNames], options, host);
+  const project: TypeScriptProject = {
+    checker: program.getTypeChecker(),
+    program,
+    sourceFileIndexes: new WeakMap(),
+  };
+
+  projectCache.set(cacheKey, project);
+  return project;
+}
+
+function createCompilerHost(
+  options: ts.CompilerOptions,
+  sourceOverride: SourceOverride | undefined,
+): ts.CompilerHost {
+  const host = ts.createCompilerHost(options, true);
+  if (sourceOverride === undefined) return host;
+
+  const originalFileExists = host.fileExists.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+  const sourceFileName = canonicalPath(sourceOverride.fileName);
+
+  host.fileExists = (fileName) => {
+    if (canonicalPath(fileName) === sourceFileName) return true;
+    return originalFileExists(fileName);
+  };
+  host.readFile = (fileName) => {
+    if (canonicalPath(fileName) === sourceFileName) return sourceOverride.text;
+    return originalReadFile(fileName);
+  };
+
+  return host;
+}
+
+function getProjectSourceFile(program: ts.Program, fileName: string): ts.SourceFile | undefined {
+  const direct = program.getSourceFile(fileName);
+  if (direct !== undefined) return direct;
+
+  const canonicalFileName = canonicalPath(fileName);
+  return program
+    .getSourceFiles()
+    .find((sourceFile) => canonicalPath(sourceFile.fileName) === canonicalFileName);
+}
+
+function findTypeScriptNodeAtRange(
+  project: TypeScriptProject,
+  sourceFile: ts.SourceFile,
+  range: readonly [number, number],
+): ts.Node | undefined {
+  const index = getSourceFileIndex(project, sourceFile);
+  const exactMatches = index.byRange.get(rangeKey(range[0], range[1]));
+  const exactExpression = findLastNode(exactMatches, ts.isExpression);
+  if (exactExpression !== undefined) return exactExpression;
+  if (exactMatches !== undefined && exactMatches.length > 0)
+    return exactMatches[exactMatches.length - 1];
+
+  return findDeepestContainedExpression(sourceFile, range[0], range[1]);
+}
+
+function getSourceFileIndex(
+  project: TypeScriptProject,
+  sourceFile: ts.SourceFile,
+): SourceFileIndex {
+  const cached = project.sourceFileIndexes.get(sourceFile);
+  if (cached !== undefined) return cached;
+
+  const index = buildSourceFileIndex(sourceFile);
+  project.sourceFileIndexes.set(sourceFile, index);
+  return index;
+}
+
+function buildSourceFileIndex(sourceFile: ts.SourceFile): SourceFileIndex {
+  const byRange = new Map<string, ts.Node[]>();
+
+  const visit = (node: ts.Node) => {
+    const key = rangeKey(node.getStart(sourceFile), node.getEnd());
+    const nodes = byRange.get(key);
+    if (nodes === undefined) {
+      byRange.set(key, [node]);
+    } else {
+      nodes.push(node);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return { byRange };
+}
+
+function findDeepestContainedExpression(
+  sourceFile: ts.SourceFile,
+  start: number,
+  end: number,
+): ts.Expression | undefined {
+  let match: ts.Expression | undefined;
+
+  const visit = (node: ts.Node) => {
+    const nodeStart = node.getStart(sourceFile);
+    const nodeEnd = node.getEnd();
+    if (nodeEnd < start || nodeStart > end) return;
+
+    if (nodeStart >= start && nodeEnd <= end && ts.isExpression(node)) {
+      match = node;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return match;
+}
+
+function findLastNode<T extends ts.Node>(
+  nodes: readonly ts.Node[] | undefined,
+  predicate: (node: ts.Node) => node is T,
+): T | undefined {
+  if (nodes === undefined) return undefined;
+
+  for (let index = nodes.length - 1; index >= 0; index -= 1) {
+    const node = nodes[index];
+    if (node !== undefined && predicate(node)) return node;
+  }
+
+  return undefined;
+}
+
+function rangeKey(start: number, end: number): string {
+  return `${start}:${end}`;
+}
+
+function isProdkitOpType(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  seen: Set<ts.Type> = new Set(),
+): boolean {
+  if (seen.has(type)) return false;
+  seen.add(type);
+
+  if (isAnyOrUnknown(type)) return false;
+  if (isProdkitOpAlias(type) || hasProdkitOpPackageShape(checker, type)) return true;
+
+  if (type.isUnion()) {
+    return type.types.some((part) => isProdkitOpType(checker, part, seen));
+  }
+
+  if (type.isIntersection()) {
+    return type.types.some((part) => isProdkitOpType(checker, part, seen));
+  }
+
+  const apparent = checker.getApparentType(type);
+  if (apparent !== type && isProdkitOpType(checker, apparent, seen)) return true;
+
+  const constraint = checker.getBaseConstraintOfType(type);
+  if (constraint !== undefined && constraint !== type) {
+    return isProdkitOpType(checker, constraint, seen);
+  }
+
+  return false;
+}
+
+function isAnyOrUnknown(type: ts.Type): boolean {
+  const flags = type.getFlags();
+  return (flags & ts.TypeFlags.Any) !== 0 || (flags & ts.TypeFlags.Unknown) !== 0;
+}
+
+function isProdkitOpAlias(type: ts.Type): boolean {
+  const aliasSymbol = type.aliasSymbol;
+  if (aliasSymbol === undefined) return false;
+
+  return symbolHasDeclarationFromPackage(aliasSymbol, prodkitOpPackageName, "Op");
+}
+
+function hasProdkitOpPackageShape(checker: ts.TypeChecker, type: ts.Type): boolean {
+  const tagProperty = type.getProperty("_tag");
+  const runProperty = type.getProperty("run");
+  if (tagProperty === undefined || runProperty === undefined) return false;
+
+  const declaration = firstDeclaration(tagProperty) ?? firstDeclaration(runProperty);
+  if (declaration === undefined) return false;
+
+  const tagType = checker.getTypeOfSymbolAtLocation(tagProperty, declaration);
+
+  return (
+    typeIncludesStringLiteral(tagType, "Op") &&
+    symbolHasDeclarationFromPackage(tagProperty, prodkitOpPackageName) &&
+    symbolHasDeclarationFromPackage(runProperty, prodkitOpPackageName)
+  );
+}
+
+function typeIncludesStringLiteral(type: ts.Type, expected: string): boolean {
+  if (type.isStringLiteral()) return type.value === expected;
+  if (type.isUnion()) return type.types.some((part) => typeIncludesStringLiteral(part, expected));
+
+  return false;
+}
+
+function firstDeclaration(symbol: ts.Symbol): ts.Declaration | undefined {
+  return symbol.declarations?.[0];
+}
+
+function symbolHasDeclarationFromPackage(
+  symbol: ts.Symbol,
+  packageName: string,
+  declarationName?: string,
+): boolean {
+  return (
+    symbol.declarations?.some((declaration) => {
+      if (declarationName !== undefined && declarationIdentifier(declaration) !== declarationName) {
+        return false;
+      }
+
+      return packageNameForFile(declaration.getSourceFile().fileName) === packageName;
+    }) ?? false
+  );
+}
+
+function declarationIdentifier(declaration: ts.Declaration): string | undefined {
+  const name = ts.getNameOfDeclaration(declaration);
+  return name !== undefined && ts.isIdentifier(name) ? name.text : undefined;
+}
+
+function packageNameForFile(fileName: string): string | undefined {
+  let dir = dirname(canonicalPath(fileName));
+
+  while (true) {
+    const cached = packageNameCache.get(dir);
+    if (packageNameCache.has(dir)) return cached;
+
+    const packageJsonPath = join(dir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      const packageName = readPackageName(packageJsonPath);
+      packageNameCache.set(dir, packageName);
+      return packageName;
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) {
+      packageNameCache.set(dir, undefined);
+      return undefined;
+    }
+
+    dir = parent;
+  }
+}
+
+function readPackageName(packageJsonPath: string): string | undefined {
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    return isRecordLike(packageJson) && typeof packageJson["name"] === "string"
+      ? packageJson["name"]
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function canonicalPath(fileName: string): string {
+  const normalized = normalize(fileName);
+  const cached = canonicalPathCache.get(normalized);
+  if (cached !== undefined) return cached;
+
+  const canonical = safeRealpath(normalized);
+  canonicalPathCache.set(normalized, canonical);
+  return canonical;
+}
+
+function safeRealpath(fileName: string): string {
+  try {
+    return normalize(realpathSync.native(fileName));
+  } catch {
+    return normalize(resolve(fileName));
+  }
+}

--- a/packages/op-lint/src/rules/require-yield-star.ts
+++ b/packages/op-lint/src/rules/require-yield-star.ts
@@ -23,7 +23,7 @@ type RangedNode = {
 };
 
 type RuleContext = TypeAwareRuleContext & {
-  report(diagnostic: { node: RangedNode; messageId: "missingYieldStar" }): void;
+  report(diagnostic: { node: RangedNode; messageId: "missingYieldStar"; fix?: FixFunction }): void;
 };
 
 type FunctionLikeNode = RangedNode & {
@@ -40,6 +40,22 @@ type CallExpressionNode = RangedNode & {
   callee: unknown;
 };
 
+type ReturnStatementNode = RangedNode & {
+  type: "ReturnStatement";
+  argument?: unknown;
+};
+
+type YieldExpressionNode = RangedNode & {
+  type: "YieldExpression";
+  argument?: unknown;
+  delegate?: boolean;
+};
+
+type AwaitExpressionNode = RangedNode & {
+  type: "AwaitExpression";
+  argument?: unknown;
+};
+
 type StaticMemberExpressionNode = RangedNode & {
   type: "MemberExpression";
   object: unknown;
@@ -51,6 +67,18 @@ type IdentifierNode = RangedNode & {
   type: "Identifier";
   name: string;
 };
+
+type Fix = {
+  range: [number, number];
+  text: string;
+};
+
+type Fixer = {
+  insertTextBefore(nodeOrToken: RangedNode, text: string): Fix;
+  replaceTextRange(range: [number, number], text: string): Fix;
+};
+
+type FixFunction = (fixer: Fixer) => Fix | Fix[] | Iterable<Fix> | null;
 
 function isNode(value: unknown): value is RangedNode {
   if (!isRecordLike(value)) return false;
@@ -109,6 +137,30 @@ function isExpressionStatement(value: unknown): value is ExpressionStatementNode
   );
 }
 
+function isReturnStatement(value: unknown): value is ReturnStatementNode {
+  return (
+    isRecordLike(value) &&
+    isNodeWithType(value, "ReturnStatement") &&
+    Object.hasOwn(value, "argument")
+  );
+}
+
+function isYieldExpression(value: unknown): value is YieldExpressionNode {
+  return (
+    isRecordLike(value) &&
+    isNodeWithType(value, "YieldExpression") &&
+    Object.hasOwn(value, "argument")
+  );
+}
+
+function isAwaitExpression(value: unknown): value is AwaitExpressionNode {
+  return (
+    isRecordLike(value) &&
+    isNodeWithType(value, "AwaitExpression") &&
+    Object.hasOwn(value, "argument")
+  );
+}
+
 function isFunctionLike(value: unknown): value is FunctionLikeNode {
   if (!isRecordLike(value)) return false;
   const generator = value["generator"];
@@ -131,10 +183,11 @@ export const requireYieldStarRule = {
   meta: {
     type: "problem" as const,
     docs: {
-      description: "Require composing direct Op builder calls with yield* inside generators.",
+      description: "Require composing Ops with yield* inside generators.",
       recommended: true,
       url: docsUrl,
     },
+    fixable: "code" as const,
     messages: {
       missingYieldStar: "Compose this Op with yield* so it runs inside the generator.",
     },
@@ -168,6 +221,42 @@ export const requireYieldStarRule = {
         context.report({
           node,
           messageId: "missingYieldStar",
+          fix: (fixer) => fixer.insertTextBefore(asRangedNode(node.expression), "yield* "),
+        });
+      },
+      ReturnStatement(node: unknown) {
+        if (!isInsideCurrentGenerator()) return;
+        if (!isReturnStatement(node)) return;
+        if (isYieldExpression(node.argument) || isAwaitExpression(node.argument)) return;
+        if (!isOpExpression(node.argument, opTypeDetector)) return;
+
+        context.report({
+          node,
+          messageId: "missingYieldStar",
+          fix: (fixer) => fixer.insertTextBefore(asRangedNode(node.argument), "yield* "),
+        });
+      },
+      YieldExpression(node: unknown) {
+        if (!isInsideCurrentGenerator()) return;
+        if (!isYieldExpression(node)) return;
+        if (node.delegate === true) return;
+        if (!isOpExpression(node.argument, opTypeDetector)) return;
+
+        context.report({
+          node,
+          messageId: "missingYieldStar",
+          fix: (fixer) => fixer.replaceTextRange(keywordRange(node, "yield"), "yield*"),
+        });
+      },
+      AwaitExpression(node: unknown) {
+        if (!isInsideCurrentGenerator()) return;
+        if (!isAwaitExpression(node)) return;
+        if (!isOpExpression(node.argument, opTypeDetector)) return;
+
+        context.report({
+          node,
+          messageId: "missingYieldStar",
+          fix: (fixer) => fixer.replaceTextRange(keywordRange(node, "await"), "yield*"),
         });
       },
     };
@@ -178,8 +267,27 @@ function isOpExpressionStatement(
   expression: unknown,
   opTypeDetector: ReturnType<typeof createOpTypeDetector>,
 ): boolean {
+  if (isYieldExpression(expression) || isAwaitExpression(expression)) return false;
+
+  return isOpExpression(expression, opTypeDetector);
+}
+
+function isOpExpression(
+  expression: unknown,
+  opTypeDetector: ReturnType<typeof createOpTypeDetector>,
+): boolean {
   if (isDirectOpBuilderCall(expression)) return true;
   if (opTypeDetector === undefined || !isNode(expression)) return false;
 
   return opTypeDetector.isOpExpression(expression);
+}
+
+function asRangedNode(node: unknown): RangedNode {
+  if (isNode(node)) return node;
+
+  throw new TypeError("Expected ranged AST node for require-yield-star autofix.");
+}
+
+function keywordRange(node: RangedNode, keyword: "await" | "yield"): [number, number] {
+  return [node.range[0], node.range[0] + keyword.length];
 }

--- a/packages/op-lint/src/rules/require-yield-star.ts
+++ b/packages/op-lint/src/rules/require-yield-star.ts
@@ -1,4 +1,5 @@
 import { isRecordLike } from "@prodkit/shared/runtime";
+import { createOpTypeDetector, type TypeAwareRuleContext } from "../op-type-detector.js";
 
 const docsUrl = "https://github.com/trvswgnr/prodkit/tree/main/packages/op-lint#require-yield-star";
 
@@ -21,7 +22,7 @@ type RangedNode = {
   loc?: unknown;
 };
 
-type RuleContext = {
+type RuleContext = TypeAwareRuleContext & {
   report(diagnostic: { node: RangedNode; messageId: "missingYieldStar" }): void;
 };
 
@@ -140,6 +141,7 @@ export const requireYieldStarRule = {
     schema: [],
   },
   create(context: RuleContext) {
+    const opTypeDetector = createOpTypeDetector(context);
     const functionStack: boolean[] = [];
     const enterFunction = (node: unknown) => {
       functionStack.push(isFunctionLike(node) && node.generator === true);
@@ -161,7 +163,7 @@ export const requireYieldStarRule = {
       ExpressionStatement(node: unknown) {
         if (!isInsideCurrentGenerator()) return;
         if (!isExpressionStatement(node)) return;
-        if (!isDirectOpBuilderCall(node.expression)) return;
+        if (!isOpExpressionStatement(node.expression, opTypeDetector)) return;
 
         context.report({
           node,
@@ -171,3 +173,13 @@ export const requireYieldStarRule = {
     };
   },
 };
+
+function isOpExpressionStatement(
+  expression: unknown,
+  opTypeDetector: ReturnType<typeof createOpTypeDetector>,
+): boolean {
+  if (isDirectOpBuilderCall(expression)) return true;
+  if (opTypeDetector === undefined || !isNode(expression)) return false;
+
+  return opTypeDetector.isOpExpression(expression);
+}

--- a/packages/op-lint/src/rules/require-yield-star.ts
+++ b/packages/op-lint/src/rules/require-yield-star.ts
@@ -1,0 +1,173 @@
+import { isRecordLike } from "@prodkit/shared/runtime";
+
+const docsUrl = "https://github.com/trvswgnr/prodkit/tree/main/packages/op-lint#require-yield-star";
+
+const opBuilderNames = new Set([
+  "all",
+  "allSettled",
+  "any",
+  "defer",
+  "fail",
+  "of",
+  "race",
+  "settle",
+  "sleep",
+  "try",
+]);
+
+type RangedNode = {
+  type: string;
+  range: readonly [number, number];
+  loc?: unknown;
+};
+
+type RuleContext = {
+  report(diagnostic: { node: RangedNode; messageId: "missingYieldStar" }): void;
+};
+
+type FunctionLikeNode = RangedNode & {
+  generator?: boolean;
+};
+
+type ExpressionStatementNode = RangedNode & {
+  type: "ExpressionStatement";
+  expression: unknown;
+};
+
+type CallExpressionNode = RangedNode & {
+  type: "CallExpression";
+  callee: unknown;
+};
+
+type StaticMemberExpressionNode = RangedNode & {
+  type: "MemberExpression";
+  object: unknown;
+  property: unknown;
+  computed: false;
+};
+
+type IdentifierNode = RangedNode & {
+  type: "Identifier";
+  name: string;
+};
+
+function isNode(value: unknown): value is RangedNode {
+  if (!isRecordLike(value)) return false;
+
+  const range = value["range"];
+  return (
+    typeof value["type"] === "string" &&
+    Array.isArray(range) &&
+    range.length === 2 &&
+    typeof range[0] === "number" &&
+    typeof range[1] === "number"
+  );
+}
+
+function isNodeWithType<T extends string>(
+  value: unknown,
+  type: T,
+): value is RangedNode & { type: T } {
+  return isNode(value) && value.type === type;
+}
+
+function isIdentifier(value: unknown): value is IdentifierNode {
+  if (!isRecordLike(value)) return false;
+  const name = value["name"];
+
+  return isNodeWithType(value, "Identifier") && typeof name === "string";
+}
+
+function isIdentifierNamed(value: unknown, name: string): value is IdentifierNode {
+  return isIdentifier(value) && value.name === name;
+}
+
+function isStaticMemberExpression(value: unknown): value is StaticMemberExpressionNode {
+  if (!isRecordLike(value)) return false;
+  const computed = value["computed"];
+
+  return (
+    isNodeWithType(value, "MemberExpression") &&
+    computed === false &&
+    Object.hasOwn(value, "object") &&
+    Object.hasOwn(value, "property")
+  );
+}
+
+function isCallExpression(value: unknown): value is CallExpressionNode {
+  return (
+    isRecordLike(value) && isNodeWithType(value, "CallExpression") && Object.hasOwn(value, "callee")
+  );
+}
+
+function isExpressionStatement(value: unknown): value is ExpressionStatementNode {
+  return (
+    isRecordLike(value) &&
+    isNodeWithType(value, "ExpressionStatement") &&
+    Object.hasOwn(value, "expression")
+  );
+}
+
+function isFunctionLike(value: unknown): value is FunctionLikeNode {
+  if (!isRecordLike(value)) return false;
+  const generator = value["generator"];
+
+  return isNode(value) && typeof generator === "boolean";
+}
+
+export function isDirectOpBuilderCall(expression: unknown): expression is CallExpressionNode {
+  if (!isCallExpression(expression)) return false;
+  if (!isStaticMemberExpression(expression.callee)) return false;
+
+  const { object, property } = expression.callee;
+
+  return (
+    isIdentifierNamed(object, "Op") && isIdentifier(property) && opBuilderNames.has(property.name)
+  );
+}
+
+export const requireYieldStarRule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description: "Require composing direct Op builder calls with yield* inside generators.",
+      recommended: true,
+      url: docsUrl,
+    },
+    messages: {
+      missingYieldStar: "Compose this Op with yield* so it runs inside the generator.",
+    },
+    schema: [],
+  },
+  create(context: RuleContext) {
+    const functionStack: boolean[] = [];
+    const enterFunction = (node: unknown) => {
+      functionStack.push(isFunctionLike(node) && node.generator === true);
+    };
+    const exitFunction = () => {
+      functionStack.pop();
+    };
+    const isInsideCurrentGenerator = () => functionStack.at(-1) === true;
+
+    return {
+      FunctionDeclaration: enterFunction,
+      "FunctionDeclaration:exit": exitFunction,
+      FunctionExpression: enterFunction,
+      "FunctionExpression:exit": exitFunction,
+      ArrowFunctionExpression() {
+        functionStack.push(false);
+      },
+      "ArrowFunctionExpression:exit": exitFunction,
+      ExpressionStatement(node: unknown) {
+        if (!isInsideCurrentGenerator()) return;
+        if (!isExpressionStatement(node)) return;
+        if (!isDirectOpBuilderCall(node.expression)) return;
+
+        context.report({
+          node,
+          messageId: "missingYieldStar",
+        });
+      },
+    };
+  },
+};

--- a/packages/op-lint/tsconfig.json
+++ b/packages/op-lint/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@prodkit/shared/tsconfig/publishable",
+  "compilerOptions": {
+    "types": ["@prodkit/shared", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/op-lint/tsdown.config.ts
+++ b/packages/op-lint/tsdown.config.ts
@@ -1,5 +1,9 @@
 import { publishableTsdown } from "@prodkit/shared/tsdown/publishable";
 
 export default publishableTsdown({
+  deps: {
+    alwaysBundle: [/^@prodkit\/shared(\/|$)/],
+    neverBundle: ["typescript"],
+  },
   entry: ["src/index.ts"],
 });

--- a/packages/op-lint/tsdown.config.ts
+++ b/packages/op-lint/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { publishableTsdown } from "@prodkit/shared/tsdown/publishable";
+
+export default publishableTsdown({
+  entry: ["src/index.ts"],
+});

--- a/packages/op-lint/vitest.config.ts
+++ b/packages/op-lint/vitest.config.ts
@@ -1,0 +1,17 @@
+import publishable from "@prodkit/shared/vitest/publishable";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  publishable,
+  defineConfig({
+    test: {
+      coverage: {
+        exclude: ["src/**/*.test.ts"],
+      },
+      include: ["src/**/*.test.ts"],
+      typecheck: {
+        include: ["src/**/*.test.ts"],
+      },
+    },
+  }),
+);

--- a/packages/shared/config/tsdown.publishable.ts
+++ b/packages/shared/config/tsdown.publishable.ts
@@ -1,6 +1,6 @@
 import { defineConfig, type UserConfig } from "tsdown";
 
-/** Shared tsdown defaults for publishable packages (`@prodkit/op`, `@prodkit/std`). */
+/** Shared tsdown defaults for publishable `@prodkit/*` packages. */
 export function publishableTsdown(config: UserConfig) {
   return defineConfig({
     format: ["esm"],

--- a/packages/shared/config/vitest.publishable.ts
+++ b/packages/shared/config/vitest.publishable.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vitest/config";
 
-/** Shared vitest defaults for publishable packages (`@prodkit/op`, `@prodkit/std`). */
+/** Shared vitest defaults for publishable `@prodkit/*` packages. */
 export default defineConfig({
   test: {
     coverage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,36 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(@types/node@24.12.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.28.1))
 
+  packages/op-lint:
+    devDependencies:
+      '@prodkit/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.3
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.0(vitest@4.1.0(@types/node@24.12.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.28.1)))
+      eslint:
+        specifier: 10.5.0
+        version: 10.5.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.48.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.55.0(oxlint-tsgolint@0.23.0)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(typescript@6.0.3)(unrun@0.3.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@types/node@24.12.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.28.1))
+
   packages/shared:
     devDependencies:
       oxfmt:
@@ -470,6 +500,56 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1183,11 +1263,17 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@24.12.3':
     resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
@@ -1230,9 +1316,22 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
@@ -1255,11 +1354,19 @@ packages:
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   better-result@2.9.0:
     resolution: {integrity: sha512-NHwGDGVbRlWDOce3CwcfGIrcNR9zY37ut3SVwQVfv57DZdVhxjhA4mfaHN1n8QwWnRAR4iErpW1X/eaiaUaFYg==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -1284,6 +1391,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1292,6 +1403,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -1351,8 +1465,54 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.5.0:
+    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1366,6 +1526,15 @@ packages:
     resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
     engines: {node: '>=12.17.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1375,9 +1544,24 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -1412,6 +1596,10 @@ packages:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1442,9 +1630,28 @@ packages:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   import-without-cache@0.4.0:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1466,9 +1673,25 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1544,6 +1767,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1575,6 +1802,10 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1583,12 +1814,19 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   oxfmt@0.48.0:
     resolution: {integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==}
@@ -1609,17 +1847,33 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1635,9 +1889,17 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -1688,6 +1950,14 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1778,6 +2048,10 @@ packages:
     resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1802,6 +2076,9 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   valibot@1.4.0:
     resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
@@ -1889,10 +2166,19 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   workerd@1.20260611.1:
     resolution: {integrity: sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==}
@@ -1910,6 +2196,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -2096,6 +2386,52 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)':
+    dependencies:
+      eslint: 10.5.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0': {}
 
@@ -2509,9 +2845,13 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/jsesc@2.5.1': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@24.12.3':
     dependencies:
@@ -2572,11 +2912,24 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansis@4.2.0: {}
 
@@ -2606,9 +2959,15 @@ snapshots:
       - debug
       - supports-color
 
+  balanced-match@4.0.4: {}
+
   better-result@2.9.0: {}
 
   birpc@4.0.0: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   cac@7.0.0: {}
 
@@ -2627,9 +2986,17 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-is@0.1.4: {}
 
   defu@6.1.7: {}
 
@@ -2700,9 +3067,75 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.5.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -2714,14 +3147,36 @@ snapshots:
     dependencies:
       pure-rand: 8.4.0
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
 
   find-up@6.3.0:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   follow-redirects@1.16.0: {}
 
@@ -2760,6 +3215,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
@@ -2785,7 +3244,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ignore@5.3.2: {}
+
   import-without-cache@0.4.0: {}
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2804,7 +3275,22 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kleur@4.1.5: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2855,6 +3341,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
@@ -2893,13 +3383,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
+  natural-compare@1.4.0: {}
+
   node-gyp-build@4.8.4: {}
 
   obug@2.1.1: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
 
   oxfmt@0.48.0:
     dependencies:
@@ -2957,15 +3462,27 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.55.0
       oxlint-tsgolint: 0.23.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.2.2
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
 
+  path-exists@4.0.0: {}
+
   path-exists@5.0.0: {}
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -2979,7 +3496,11 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   proxy-from-env@2.1.0: {}
+
+  punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
@@ -3080,6 +3601,12 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -3149,6 +3676,10 @@ snapshots:
       '@turbo/windows-64': 2.9.18
       '@turbo/windows-arm64': 2.9.18
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   typescript@6.0.3: {}
 
   unconfig-core@7.5.0:
@@ -3163,6 +3694,10 @@ snapshots:
   unrun@0.3.0:
     dependencies:
       rolldown: 1.0.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   valibot@1.4.0(typescript@6.0.3):
     optionalDependencies:
@@ -3207,10 +3742,16 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
 
   workerd@1.20260611.1:
     optionalDependencies:
@@ -3221,6 +3762,8 @@ snapshots:
       '@cloudflare/workerd-windows-64': 1.20260611.1
 
   ws@8.20.1: {}
+
+  yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
 

--- a/tools/checks/check-public-docs.test.ts
+++ b/tools/checks/check-public-docs.test.ts
@@ -21,6 +21,8 @@ void test("slugifyHeading matches package README policy anchors", () => {
 void test("broken relative and github links are reported", () => {
   const root = mkdtempSync(path.join(tmpdir(), "public-docs-check-"));
   mkdirSync(path.join(root, "packages/op/docs"), { recursive: true });
+  mkdirSync(path.join(root, "packages/op-lint"), { recursive: true });
+  mkdirSync(path.join(root, "packages/std"), { recursive: true });
   writeFileSync(path.join(root, "README.md"), "[root](packages/op/README.md)\n", "utf8");
   writeFileSync(
     path.join(root, "packages/op/README.md"),
@@ -31,6 +33,8 @@ void test("broken relative and github links are reported", () => {
     ].join("\n"),
     "utf8",
   );
+  writeFileSync(path.join(root, "packages/op-lint/README.md"), "# @prodkit/op-lint\n", "utf8");
+  writeFileSync(path.join(root, "packages/std/README.md"), "# @prodkit/std\n", "utf8");
   writeFileSync(path.join(root, "packages/op/docs/README.md"), "## Guides\n", "utf8");
 
   const issues = checkPublicDocs(root);

--- a/tools/checks/lib/check-public-docs.ts
+++ b/tools/checks/lib/check-public-docs.ts
@@ -9,7 +9,13 @@ export function listPublicDocRelativePaths(repoRoot: string): string[] {
         .sort()
         .map((entry) => `packages/op/docs/${entry}`)
     : [];
-  return ["README.md", "packages/op/README.md", ...guideDocs];
+  return [
+    "README.md",
+    "packages/op/README.md",
+    "packages/op-lint/README.md",
+    "packages/std/README.md",
+    ...guideDocs,
+  ];
 }
 
 const MARKDOWN_LINK = /\[([^\]]*)\]\(([^)]+)\)/g;

--- a/tools/release/release-packages.ts
+++ b/tools/release/release-packages.ts
@@ -6,6 +6,11 @@ export const RELEASE_PACKAGES = {
     packageDir: "packages/op",
     tagPrefix: "op",
   },
+  "op-lint": {
+    npmName: "@prodkit/op-lint",
+    packageDir: "packages/op-lint",
+    tagPrefix: "op-lint",
+  },
   std: {
     npmName: "@prodkit/std",
     packageDir: "packages/std",
@@ -26,7 +31,7 @@ export function releaseTag(id: ReleasePackageId, version: string): string {
 }
 
 export const RELEASE_CUT_USAGE =
-  "usage: node ./tools/release/release-cut.ts <op|std> <patch|minor|major>";
+  "usage: node ./tools/release/release-cut.ts <op|op-lint|std> <patch|minor|major>";
 
 export const CHANGELOG_CHECK_USAGE =
-  "usage: node ./tools/release/check-changelog-version.ts <op|std>";
+  "usage: node ./tools/release/check-changelog-version.ts <op|op-lint|std>";


### PR DESCRIPTION
## Summary

Op generator bodies only run child Ops when they are composed with `yield*`, but the common mistakes (`Op.of(1);`, `return loadUser()`, `yield loadUser()`, `await loadUser()`) type-check and fail silently at runtime. This PR adds `@prodkit/op-lint`, a publishable ESLint-compatible plugin that loads in Oxlint JavaScript plugins and ESLint flat config.

The initial `prodkit-op/require-yield-star` rule reports those mis-compositions inside generator bodies and autofixes mechanical rewrites to `yield*`. Detection starts with direct `Op.<builder>(...)` calls and, when TypeScript resolution is available, follows aliases, imports, generic `Op` parameters, properties, and methods typed as Ops. The checker is conservative: it ignores `any`/`unknown`, non-Op iterables, and structural lookalikes that do not come from `@prodkit/op`.

Repo plumbing treats `@prodkit/op-lint` as a third publishable package: release workflow (`op-lint-v*` tags), contributor docs, public docs checks, and package tests that smoke-load the built plugin through Oxlint and ESLint.

## Validation Steps

- Run `pnpm run gate` from the repo root.
- Run `pnpm --filter @prodkit/op-lint run test` and confirm Oxlint and ESLint smoke tests pass, RuleTester cases cover direct and type-aware Op detection, and autofixes rewrite to `yield*`.
- Optionally wire the plugin in a local project per `packages/op-lint/README.md` and confirm `prodkit-op/require-yield-star` reports ignored, returned, yielded, and awaited Ops while allowing staged locals and `return yield*`.